### PR TITLE
Drop support for cross-building on 2.9.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,19 +5,28 @@ organization := "org.spire-math"
 homepage := Some(url("http://spire-math.org"))
 licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 
-
 // build information
 
 scalaVersion := "2.11.4"
-crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.4")
+crossScalaVersions := Seq("2.10.4", "2.11.4")
 
 scalacOptions ++= (
-  "-deprecation" ::
+  "-deprecation" ::           
+  "-encoding" :: "UTF-8" ::
+  "-feature" ::                
+  "-language:existentials" ::
+  "-language:higherKinds" ::
+  "-language:implicitConversions" ::
   "-unchecked" ::
-  "-optimize" ::
+  "-Xfatal-warnings" ::       
+  "-Xlint" ::
+  "-Yno-adapted-args" ::       
+  "-Ywarn-dead-code" ::
+  "-Ywarn-numeric-widen" ::   
+  //"-Ywarn-value-discard" :: // fails with @sp on Unit
+  "-Xfuture" ::
   Nil
 )
-
 
 // publishing/release details follow
 

--- a/src/main/scala/algebra/CommutativeGroup.scala
+++ b/src/main/scala/algebra/CommutativeGroup.scala
@@ -5,8 +5,7 @@ import scala.{ specialized => sp }
 /**
  * An abelian group is a group whose operation is commutative.
  */
-trait CommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A]
-    extends Group[A] with CommutativeMonoid[A]
+trait CommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Group[A] with CommutativeMonoid[A]
 
 object CommutativeGroup extends GroupFunctions {
 

--- a/src/main/scala/algebra/CommutativeMonoid.scala
+++ b/src/main/scala/algebra/CommutativeMonoid.scala
@@ -7,8 +7,7 @@ import scala.{ specialized => sp }
  * 
  * A monoid is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeMonoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A]
-    extends Monoid[A] with CommutativeSemigroup[A]
+trait CommutativeMonoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] with CommutativeSemigroup[A]
 
 object CommutativeMonoid extends MonoidFunctions {
 

--- a/src/main/scala/algebra/CommutativeSemigroup.scala
+++ b/src/main/scala/algebra/CommutativeSemigroup.scala
@@ -7,7 +7,7 @@ import scala.{ specialized => sp }
  * 
  * A semigroup is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeSemigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Semigroup[A] {
+trait CommutativeSemigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
 
   /**
    * CommutativeSemigroup is guaranteed to be commutative.

--- a/src/main/scala/algebra/Eq.scala
+++ b/src/main/scala/algebra/Eq.scala
@@ -7,7 +7,7 @@ import scala.{specialized => sp}
  * type. Any 2 instances `x` and `y` are equal if `eqv(x, y)` is `true`.
  * Moreover, `eqv` should form an equivalence relation.
  */
-trait Eq[@sp A] { self =>
+trait Eq[@sp A] extends Any { self =>
 
   /**
    * Returns `true` if `x` and `y` are equivalent, `false` otherwise.

--- a/src/main/scala/algebra/Group.scala
+++ b/src/main/scala/algebra/Group.scala
@@ -5,7 +5,7 @@ import scala.{ specialized => sp }
 /**
  * A group is a monoid where each element has an inverse.
  */
-trait Group[@sp(Byte, Short, Int, Long, Float, Double) A] extends Monoid[A] {
+trait Group[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] {
 
   /**
    * Find the inverse of `a`.

--- a/src/main/scala/algebra/Monoid.scala
+++ b/src/main/scala/algebra/Monoid.scala
@@ -8,7 +8,7 @@ import scala.{ specialized => sp }
  * `combine(x, empty) == combine(empty, x) == x`. For example, if we have `Monoid[String]`,
  * with `combine` as string concatenation, then `empty = ""`.
  */
-trait Monoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Semigroup[A] {
+trait Monoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
 
   /**
    * Return the identity element for this monoid.

--- a/src/main/scala/algebra/Order.scala
+++ b/src/main/scala/algebra/Order.scala
@@ -19,7 +19,7 @@ import scala.{specialized => sp}
  * 
  * By the totality law, x <= y and y <= x cannot be both false.
  */
-trait Order[@sp A] extends PartialOrder[A] { self =>
+trait Order[@sp A] extends Any with PartialOrder[A] { self =>
 
   /**
    * Result of comparing `x` with `y`. Returns an Int whose sign is:

--- a/src/main/scala/algebra/PartialOrder.scala
+++ b/src/main/scala/algebra/PartialOrder.scala
@@ -21,7 +21,7 @@ import scala.{specialized => sp}
  * true      false       = -1.0    (corresponds to x < y)
  * false     true        = 1.0     (corresponds to x > y)
  */
-trait PartialOrder[@sp A] extends Eq[A] { self =>
+trait PartialOrder[@sp A] extends Any with Eq[A] { self =>
 
   /**
    * Result of comparing `x` with `y`. Returns NaN if operands are not

--- a/src/main/scala/algebra/Semigroup.scala
+++ b/src/main/scala/algebra/Semigroup.scala
@@ -6,7 +6,7 @@ import scala.annotation.{ switch, tailrec }
 /**
  * A semigroup is any set `A` with an associative operation (`combine`).
  */
-trait Semigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] {
+trait Semigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any {
 
   /**
    * Associative operation taking which combines two values.

--- a/src/main/scala/algebra/number/IsReal.scala
+++ b/src/main/scala/algebra/number/IsReal.scala
@@ -6,7 +6,7 @@ import scala.{ specialized => sp }
 /**
  * A simple type class for numeric types that are a subset of the reals.
  */
-trait IsReal[@sp(Byte,Short,Int,Long,Float,Double) A] extends Order[A] with Signed[A] {
+trait IsReal[@sp(Byte,Short,Int,Long,Float,Double) A] extends Any with Order[A] with Signed[A] {
   def ceil(a: A): A
   def floor(a: A): A
   def round(a: A): A
@@ -14,7 +14,7 @@ trait IsReal[@sp(Byte,Short,Int,Long,Float,Double) A] extends Order[A] with Sign
   def toDouble(a: A): Double
 }
 
-trait IsIntegral[@sp(Byte,Short,Int,Long) A] extends IsReal[A] {
+trait IsIntegral[@sp(Byte,Short,Int,Long) A] extends Any with IsReal[A] {
   def ceil(a: A): A = a
   def floor(a: A): A = a
   def round(a: A): A = a

--- a/src/main/scala/algebra/number/Signed.scala
+++ b/src/main/scala/algebra/number/Signed.scala
@@ -9,7 +9,7 @@ import scala.{ specialized => sp }
  * A trait for things that have some notion of sign and the ability to
  * ensure something has a non-negative sign.
  */
-trait Signed[@sp(Byte, Short, Int, Long, Float, Double) A] {
+trait Signed[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
 
   /**
    * Return a's sign:

--- a/src/main/scala/algebra/ring/Additive.scala
+++ b/src/main/scala/algebra/ring/Additive.scala
@@ -4,7 +4,7 @@ package ring
 import scala.{ specialized => sp }
 import scala.annotation.tailrec
 
-trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] {
+trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
   def additive: Semigroup[A] = new Semigroup[A] {
     def combine(x: A, y: A): A = plus(x, y)
   }
@@ -35,14 +35,14 @@ trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] {
     as.reduceOption(plus)
 }
 
-trait AdditiveCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends AdditiveSemigroup[A] {
+trait AdditiveCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
   override def additive: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
     def combine(x: A, y: A): A = plus(x, y)
   }
   override def hasCommutativeAddition: Boolean = true
 }
 
-trait AdditiveMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends AdditiveSemigroup[A] {
+trait AdditiveMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
   override def additive: Monoid[A] = new Monoid[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
@@ -67,14 +67,14 @@ trait AdditiveMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Addit
     as.foldLeft(zero)(plus)
 }
 
-trait AdditiveCommutativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends AdditiveMonoid[A] with AdditiveCommutativeSemigroup[A] {
+trait AdditiveCommutativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with AdditiveCommutativeSemigroup[A] {
   override def additive: CommutativeMonoid[A] = new CommutativeMonoid[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
   }
 }
 
-trait AdditiveGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends AdditiveMonoid[A] {
+trait AdditiveGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] {
   override def additive: Group[A] = new Group[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
@@ -92,7 +92,7 @@ trait AdditiveGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Additi
     else positiveSumN(negate(a), -n)
 }
 
-trait AdditiveCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends AdditiveGroup[A] with AdditiveCommutativeMonoid[A] {
+trait AdditiveCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveGroup[A] with AdditiveCommutativeMonoid[A] {
   override def additive: CommutativeGroup[A] = new CommutativeGroup[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)

--- a/src/main/scala/algebra/ring/CommutativeRig.scala
+++ b/src/main/scala/algebra/ring/CommutativeRig.scala
@@ -6,7 +6,7 @@ import scala.{specialized => sp}
 /**
  * CommutativeRig is a Rig that is commutative under multiplication.
  */
-trait CommutativeRig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Rig[A] with MultiplicativeCommutativeMonoid[A]
+trait CommutativeRig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with MultiplicativeCommutativeMonoid[A]
 
 object CommutativeRig extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit r: CommutativeRig[A]): CommutativeRig[A] = r

--- a/src/main/scala/algebra/ring/CommutativeRing.scala
+++ b/src/main/scala/algebra/ring/CommutativeRing.scala
@@ -6,7 +6,7 @@ import scala.{specialized => sp}
 /**
  * CommutativeRing is a Ring that is commutative under multiplication.
  */
-trait CommutativeRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Ring[A] with CommutativeRig[A]
+trait CommutativeRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Ring[A] with CommutativeRig[A]
 
 object CommutativeRing extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit r: CommutativeRing[A]): CommutativeRing[A] = r

--- a/src/main/scala/algebra/ring/EuclideanRing.scala
+++ b/src/main/scala/algebra/ring/EuclideanRing.scala
@@ -22,7 +22,7 @@ import scala.{specialized => sp}
  * This type does not provide access to the Euclidean function, but
  * only provides the quot, mod, and quotmod operators.
  */
-trait EuclideanRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends CommutativeRing[A] {
+trait EuclideanRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with CommutativeRing[A] {
   def mod(a: A, b: A): A
   def quot(a: A, b: A): A
   def quotmod(a: A, b: A): (A, A) = (quot(a, b), mod(a, b))

--- a/src/main/scala/algebra/ring/Field.scala
+++ b/src/main/scala/algebra/ring/Field.scala
@@ -6,7 +6,7 @@ import scala.{ specialized => sp }
 import java.lang.Double.{ isInfinite, isNaN, doubleToLongBits }
 import java.lang.Long.{ numberOfTrailingZeros }
 
-trait Field[@sp(Byte, Short, Int, Long, Float, Double) A] extends EuclideanRing[A] with MultiplicativeCommutativeGroup[A] {
+trait Field[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with EuclideanRing[A] with MultiplicativeCommutativeGroup[A] {
 
   /**
    * This is implemented in terms of basic Field ops. However, this is

--- a/src/main/scala/algebra/ring/Multiplicative.scala
+++ b/src/main/scala/algebra/ring/Multiplicative.scala
@@ -4,7 +4,7 @@ package ring
 import scala.{ specialized => sp }
 import scala.annotation.tailrec
 
-trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] {
+trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
   def multiplicative: Semigroup[A] =
     new Semigroup[A] {
       def combine(x: A, y: A): A = times(x, y)
@@ -36,14 +36,14 @@ trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] {
     as.reduceOption(times)
 }
 
-trait MultiplicativeCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends MultiplicativeSemigroup[A] {
+trait MultiplicativeCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
   override def hasCommutativeMultiplication: Boolean = false
   override def multiplicative: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
     def combine(x: A, y: A): A = times(x, y)
   }
 }
 
-trait MultiplicativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends MultiplicativeSemigroup[A] {
+trait MultiplicativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
   override def multiplicative: Monoid[A] = new Monoid[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
@@ -68,14 +68,14 @@ trait MultiplicativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends
     as.foldLeft(one)(times)
 }
 
-trait MultiplicativeCommutativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends MultiplicativeMonoid[A] with MultiplicativeCommutativeSemigroup[A] {
+trait MultiplicativeCommutativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] with MultiplicativeCommutativeSemigroup[A] {
   override def multiplicative: CommutativeMonoid[A] = new CommutativeMonoid[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
   }
 }
 
-trait MultiplicativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends MultiplicativeMonoid[A] {
+trait MultiplicativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] {
   override def multiplicative: Group[A] = new Group[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
@@ -93,7 +93,7 @@ trait MultiplicativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends 
     else positivePow(reciprocal(a), -n)
 }
 
-trait MultiplicativeCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends MultiplicativeGroup[A] with MultiplicativeCommutativeMonoid[A] {
+trait MultiplicativeCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeGroup[A] with MultiplicativeCommutativeMonoid[A] {
   override def multiplicative: CommutativeGroup[A] = new CommutativeGroup[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)

--- a/src/main/scala/algebra/ring/Rig.scala
+++ b/src/main/scala/algebra/ring/Rig.scala
@@ -8,7 +8,7 @@ import scala.{specialized => sp}
  * Rig is a ring whose additive structure doesn't have an inverse (ie. it is
  * monoid, not a group). Put another way, a Rig is a Ring without negation.
  */
-trait Rig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Semiring[A] with MultiplicativeMonoid[A]
+trait Rig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with MultiplicativeMonoid[A]
 
 object Rig extends AdditiveMonoidFunctions with MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit ev: Rig[A]): Rig[A] = ev

--- a/src/main/scala/algebra/ring/Ring.scala
+++ b/src/main/scala/algebra/ring/Ring.scala
@@ -13,7 +13,7 @@ import scala.{specialized => sp}
  * possible, these methods should be overridden by more efficient
  * implementations.
  */
-trait Ring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Rig[A] with Rng[A] {
+trait Ring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] {
 
   /**
    * Convert the given integer to an instance of A.

--- a/src/main/scala/algebra/ring/Rng.scala
+++ b/src/main/scala/algebra/ring/Rng.scala
@@ -9,7 +9,7 @@ import scala.{specialized => sp}
  * identity (i.e. it is semigroup, not a monoid). Put another way, a
  * Rng is a Ring without a multiplicative identity.
  */
-trait Rng[@sp(Byte, Short, Int, Long, Float, Double) A] extends Semiring[A] with AdditiveCommutativeGroup[A]
+trait Rng[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveCommutativeGroup[A]
 
 object Rng extends AdditiveGroupFunctions with MultiplicativeSemigroupFunctions {
   @inline final def apply[A](implicit ev: Rng[A]): Rng[A] = ev

--- a/src/main/scala/algebra/ring/Semiring.scala
+++ b/src/main/scala/algebra/ring/Semiring.scala
@@ -12,7 +12,7 @@ import scala.{specialized => sp}
  * A Semiring with a multiplicative identity (1) is a Rig.
  * A Semiring with all of the above is a Ring.
  */
-trait Semiring[@sp(Byte, Short, Int, Long, Float, Double) A] extends AdditiveMonoid[A] with MultiplicativeSemigroup[A]
+trait Semiring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with MultiplicativeSemigroup[A]
 
 object Semiring extends AdditiveMonoidFunctions with MultiplicativeSemigroupFunctions {
   @inline final def apply[A](implicit ev: Semiring[A]): Semiring[A] = ev


### PR DESCRIPTION
This means we can use universal traits for type classes.
It also means we can use some newer scalac options, as
well as possibly value classes, macros, or other new
2.10 features.
