### PR TITLE
Remove Boolean, Byte, and Short specialization from most things.

### DIFF
--- a/core/src/main/scala/algebra/BoundedSemilattice.scala
+++ b/core/src/main/scala/algebra/BoundedSemilattice.scala
@@ -4,7 +4,7 @@ import lattice.{ BoundedMeetSemilattice, BoundedJoinSemilattice }
 
 import scala.{specialized => sp}
 
-trait BoundedSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semilattice[A] with CommutativeMonoid[A] { self =>
+trait BoundedSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Semilattice[A] with CommutativeMonoid[A] { self =>
 
   override def asMeetSemilattice: BoundedMeetSemilattice[A] =
     new BoundedMeetSemilattice[A] {
@@ -25,5 +25,5 @@ object BoundedSemilattice {
   /**
    * Access an implicit `BoundedSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedSemilattice[A]): BoundedSemilattice[A] = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: BoundedSemilattice[A]): BoundedSemilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/CommutativeGroup.scala
+++ b/core/src/main/scala/algebra/CommutativeGroup.scala
@@ -5,7 +5,7 @@ import scala.{ specialized => sp }
 /**
  * An abelian group is a group whose operation is commutative.
  */
-trait CommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Group[A] with CommutativeMonoid[A]
+trait CommutativeGroup[@sp(Int, Long, Float, Double) A] extends Any with Group[A] with CommutativeMonoid[A]
 
 object CommutativeGroup extends GroupFunctions {
 

--- a/core/src/main/scala/algebra/CommutativeMonoid.scala
+++ b/core/src/main/scala/algebra/CommutativeMonoid.scala
@@ -7,7 +7,7 @@ import scala.{ specialized => sp }
  * 
  * A monoid is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeMonoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] with CommutativeSemigroup[A]
+trait CommutativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with Monoid[A] with CommutativeSemigroup[A]
 
 object CommutativeMonoid extends MonoidFunctions {
 

--- a/core/src/main/scala/algebra/CommutativeSemigroup.scala
+++ b/core/src/main/scala/algebra/CommutativeSemigroup.scala
@@ -7,7 +7,7 @@ import scala.{ specialized => sp }
  * 
  * A semigroup is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeSemigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
+trait CommutativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] {
 
   /**
    * CommutativeSemigroup is guaranteed to be commutative.

--- a/core/src/main/scala/algebra/Group.scala
+++ b/core/src/main/scala/algebra/Group.scala
@@ -5,7 +5,7 @@ import scala.{ specialized => sp }
 /**
  * A group is a monoid where each element has an inverse.
  */
-trait Group[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] {
+trait Group[@sp(Int, Long, Float, Double) A] extends Any with Monoid[A] {
 
   /**
    * Find the inverse of `a`.
@@ -33,9 +33,9 @@ trait Group[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoi
 }
 
 trait GroupFunctions extends MonoidFunctions {
-  def inverse[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Group[A]): A =
+  def inverse[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Group[A]): A =
     ev.inverse(a)
-  def remove[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Group[A]): A =
+  def remove[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Group[A]): A =
     ev.remove(x, y)
 }
 

--- a/core/src/main/scala/algebra/Monoid.scala
+++ b/core/src/main/scala/algebra/Monoid.scala
@@ -8,7 +8,7 @@ import scala.{ specialized => sp }
  * `combine(x, empty) == combine(empty, x) == x`. For example, if we have `Monoid[String]`,
  * with `combine` as string concatenation, then `empty = ""`.
  */
-trait Monoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
+trait Monoid[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] {
 
   /**
    * Return the identity element for this monoid.
@@ -36,10 +36,10 @@ trait Monoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any 
 }
 
 trait MonoidFunctions extends SemigroupFunctions {
-  def empty[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Monoid[A]): A =
+  def empty[@sp(Int, Long, Float, Double) A](implicit ev: Monoid[A]): A =
     ev.empty
 
-  def combineAll[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Monoid[A]): A =
+  def combineAll[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Monoid[A]): A =
     ev.combineAll(as)
 }
 

--- a/core/src/main/scala/algebra/Semigroup.scala
+++ b/core/src/main/scala/algebra/Semigroup.scala
@@ -6,7 +6,7 @@ import scala.annotation.{ switch, tailrec }
 /**
  * A semigroup is any set `A` with an associative operation (`combine`).
  */
-trait Semigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Serializable {
+trait Semigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
 
   /**
    * Associative operation taking which combines two values.
@@ -49,19 +49,19 @@ trait Semigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends A
 }
 
 trait SemigroupFunctions {
-  def combine[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Semigroup[A]): A =
+  def combine[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Semigroup[A]): A =
     ev.combine(x, y)
 
-  def maybeCombine[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: Semigroup[A]): A =
+  def maybeCombine[@sp(Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: Semigroup[A]): A =
     ox match {
       case Some(x) => ev.combine(x, y)
       case None => y
     }
 
-  def combineN[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: Semigroup[A]): A =
+  def combineN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: Semigroup[A]): A =
     ev.combineN(a, n)
 
-  def combineAllOption[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Semigroup[A]): Option[A] =
+  def combineAllOption[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Semigroup[A]): Option[A] =
     ev.combineAllOption(as)
 }
 

--- a/core/src/main/scala/algebra/Semilattice.scala
+++ b/core/src/main/scala/algebra/Semilattice.scala
@@ -9,7 +9,7 @@ import scala.{specialized => sp}
  * Semilattices are commutative semigroups whose operation
  * (i.e. combine) is also idempotent.
  */
-trait Semilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with CommutativeSemigroup[A] { self =>
+trait Semilattice[@sp(Int, Long, Float, Double) A] extends Any with CommutativeSemigroup[A] { self =>
 
   /**
    * Given Eq[A], return a PartialOrder[A] using the `combine`
@@ -69,5 +69,5 @@ object Semilattice {
   /**
    * Access an implicit `Semilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Semilattice[A]): Semilattice[A] = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: Semilattice[A]): Semilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/Bool.scala
+++ b/core/src/main/scala/algebra/lattice/Bool.scala
@@ -22,13 +22,13 @@ import scala.{specialized => sp}
  * Every boolean algebras has a dual algebra, which involves reversing
  * true/false as well as and/or.
  */
-trait Bool[@sp(Boolean, Byte, Short, Int, Long) A] extends Any with Heyting[A] {
+trait Bool[@sp(Int, Long) A] extends Any with Heyting[A] {
   def imp(a: A, b: A): A = or(complement(a), b)
 
   def dual: Bool[A] = new DualBool(this)
 }
 
-class DualBool[@sp(Boolean, Byte, Short, Int, Long) A](orig: Bool[A]) extends Bool[A] {
+class DualBool[@sp(Int, Long) A](orig: Bool[A]) extends Bool[A] {
   def one: A = orig.zero
   def zero: A = orig.one
   def and(a: A, b: A): A = orig.or(a, b)
@@ -45,15 +45,15 @@ class DualBool[@sp(Boolean, Byte, Short, Int, Long) A](orig: Bool[A]) extends Bo
 }
 
 trait BoolFunctions {
-  def dual[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): Bool[A] =
+  def dual[@sp(Int, Long) A](implicit ev: Bool[A]): Bool[A] =
     ev.dual
-  def xor[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def xor[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.xor(x, y)
-  def nand[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def nand[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.nand(x, y)
-  def nor[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def nor[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.nor(x, y)
-  def nxor[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def nxor[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.nxor(x, y)
 }
 
@@ -62,5 +62,5 @@ object Bool extends HeytingFunctions with BoolFunctions {
   /**
    * Access an implicit `Bool[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): Bool[A] = ev
+  @inline final def apply[@sp(Int, Long) A](implicit ev: Bool[A]): Bool[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
+++ b/core/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
@@ -3,7 +3,7 @@ package lattice
 
 import scala.{specialized => sp}
 
-trait BoundedJoinSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] { self =>
+trait BoundedJoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] { self =>
   def zero: A
   def isZero(a: A)(implicit ev: Eq[A]): Boolean = ev.eqv(a, zero)
 
@@ -19,5 +19,5 @@ object BoundedJoinSemilattice {
   /**
    * Access an implicit `BoundedJoinSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedJoinSemilattice[A]): BoundedJoinSemilattice[A] = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: BoundedJoinSemilattice[A]): BoundedJoinSemilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/BoundedLattice.scala
+++ b/core/src/main/scala/algebra/lattice/BoundedLattice.scala
@@ -16,13 +16,13 @@ import scala.{specialized => sp}
  * 
  *   (0 ∨ a) = a = (1 ∧ a)
  */
-trait BoundedLattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Lattice[A] with BoundedMeetSemilattice[A] with BoundedJoinSemilattice[A]
+trait BoundedLattice[@sp(Int, Long, Float, Double) A] extends Any with Lattice[A] with BoundedMeetSemilattice[A] with BoundedJoinSemilattice[A]
 
 trait BoundedLatticeFunctions {
-  def zero[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedJoinSemilattice[A]): A =
+  def zero[@sp(Int, Long, Float, Double) A](implicit ev: BoundedJoinSemilattice[A]): A =
     ev.zero
 
-  def one[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedMeetSemilattice[A]): A =
+  def one[@sp(Int, Long, Float, Double) A](implicit ev: BoundedMeetSemilattice[A]): A =
     ev.one
 }
 
@@ -31,5 +31,5 @@ object BoundedLattice extends LatticeFunctions with BoundedLatticeFunctions {
   /**
    * Access an implicit `BoundedLattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedLattice[A]): BoundedLattice[A] = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: BoundedLattice[A]): BoundedLattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
+++ b/core/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
@@ -3,7 +3,7 @@ package lattice
 
 import scala.{specialized => sp}
 
-trait BoundedMeetSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with MeetSemilattice[A] { self =>
+trait BoundedMeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with MeetSemilattice[A] { self =>
   def one: A
   def isOne(a: A)(implicit ev: Eq[A]): Boolean = ev.eqv(a, one)
 
@@ -19,5 +19,5 @@ object BoundedMeetSemilattice {
   /**
    * Access an implicit `BoundedMeetSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedMeetSemilattice[A]): BoundedMeetSemilattice[A] = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: BoundedMeetSemilattice[A]): BoundedMeetSemilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/Heyting.scala
+++ b/core/src/main/scala/algebra/lattice/Heyting.scala
@@ -35,7 +35,7 @@ import scala.{specialized => sp}
  * classical logic, see the boolean algebra type class implemented as
  * `Bool`.
  */
-trait Heyting[@sp(Boolean, Byte, Short, Int, Long) A] extends Any with BoundedLattice[A] { self =>
+trait Heyting[@sp(Int, Long) A] extends Any with BoundedLattice[A] { self =>
   def and(a: A, b: A): A
   def meet(a: A, b: A): A = and(a, b)
 
@@ -61,17 +61,17 @@ trait Heyting[@sp(Boolean, Byte, Short, Int, Long) A] extends Any with BoundedLa
 }
 
 trait HeytingFunctions {
-  def zero[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): A = ev.zero
-  def one[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): A = ev.one
+  def zero[@sp(Int, Long) A](implicit ev: Bool[A]): A = ev.zero
+  def one[@sp(Int, Long) A](implicit ev: Bool[A]): A = ev.one
 
-  def complement[@sp(Boolean, Byte, Short, Int, Long) A](x: A)(implicit ev: Bool[A]): A =
+  def complement[@sp(Int, Long) A](x: A)(implicit ev: Bool[A]): A =
     ev.complement(x)
 
-  def and[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def and[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.and(x, y)
-  def or[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def or[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.or(x, y)
-  def imp[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def imp[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.imp(x, y)
 }
 
@@ -81,5 +81,5 @@ object Heyting extends HeytingFunctions {
   /**
    * Access an implicit `Heyting[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Heyting[A]): Heyting[A] = ev
+  @inline final def apply[@sp(Int, Long) A](implicit ev: Heyting[A]): Heyting[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/JoinSemilattice.scala
+++ b/core/src/main/scala/algebra/lattice/JoinSemilattice.scala
@@ -8,7 +8,7 @@ import scala.{specialized => sp}
  * operation is called "join", and which can be thought of as a least
  * upper bound.
  */
-trait JoinSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Serializable { self =>
+trait JoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializable { self =>
   def join(lhs: A, rhs: A): A
 
   def joinSemilattice: Semilattice[A] =
@@ -25,6 +25,6 @@ object JoinSemilattice {
   /**
    * Access an implicit `JoinSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: JoinSemilattice[A]): JoinSemilattice[A] = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: JoinSemilattice[A]): JoinSemilattice[A] = ev
 
 }

--- a/core/src/main/scala/algebra/lattice/Lattice.scala
+++ b/core/src/main/scala/algebra/lattice/Lattice.scala
@@ -27,13 +27,13 @@ import scala.{specialized => sp}
  *   - ∧ for meet
  *   - ∨ for join
  */
-trait Lattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] with MeetSemilattice[A]
+trait Lattice[@sp(Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] with MeetSemilattice[A]
 
 trait LatticeFunctions {
-  def join[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: JoinSemilattice[A]): A =
+  def join[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: JoinSemilattice[A]): A =
     ev.join(x, y)
 
-  def meet[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MeetSemilattice[A]): A =
+  def meet[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MeetSemilattice[A]): A =
     ev.meet(x, y)
 }
 
@@ -42,5 +42,5 @@ object Lattice extends LatticeFunctions {
   /**
    * Access an implicit `Lattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Lattice[A]): Lattice[A] = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: Lattice[A]): Lattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/MeetSemilattice.scala
+++ b/core/src/main/scala/algebra/lattice/MeetSemilattice.scala
@@ -8,7 +8,7 @@ import scala.{specialized => sp}
  * operation is called "meet", and which can be thought of as a
  * greatest lower bound.
  */
-trait MeetSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Serializable { self =>
+trait MeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializable { self =>
   def meet(lhs: A, rhs: A): A
 
   def meetSemilattice: Semilattice[A] =
@@ -25,5 +25,5 @@ object MeetSemilattice {
   /**
    * Access an implicit `MeetSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: MeetSemilattice[A]): MeetSemilattice[A] = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: MeetSemilattice[A]): MeetSemilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/number/IsReal.scala
+++ b/core/src/main/scala/algebra/number/IsReal.scala
@@ -6,7 +6,7 @@ import scala.{ specialized => sp }
 /**
  * A simple type class for numeric types that are a subset of the reals.
  */
-trait IsReal[@sp(Byte,Short,Int,Long,Float,Double) A] extends Any with Order[A] with Signed[A] {
+trait IsReal[@sp(Int, Long, Float, Double) A] extends Any with Order[A] with Signed[A] {
   def ceil(a: A): A
   def floor(a: A): A
   def round(a: A): A
@@ -14,7 +14,7 @@ trait IsReal[@sp(Byte,Short,Int,Long,Float,Double) A] extends Any with Order[A] 
   def toDouble(a: A): Double
 }
 
-trait IsIntegral[@sp(Byte,Short,Int,Long) A] extends Any with IsReal[A] {
+trait IsIntegral[@sp(Int, Long) A] extends Any with IsReal[A] {
   def ceil(a: A): A = a
   def floor(a: A): A = a
   def round(a: A): A = a
@@ -22,15 +22,15 @@ trait IsIntegral[@sp(Byte,Short,Int,Long) A] extends Any with IsReal[A] {
 }
 
 trait IsRealFunctions {
-  def ceil[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): A =
+  def ceil[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: IsReal[A]): A =
     ev.ceil(a)
-  def floor[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): A =
+  def floor[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: IsReal[A]): A =
     ev.floor(a)
-  def round[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): A =
+  def round[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: IsReal[A]): A =
     ev.round(a)
-  def isWhole[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): Boolean =
+  def isWhole[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: IsReal[A]): Boolean =
     ev.isWhole(a)
-  def toDouble[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): Double =
+  def toDouble[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: IsReal[A]): Double =
     ev.toDouble(a)
 }
 

--- a/core/src/main/scala/algebra/number/NRoot.scala
+++ b/core/src/main/scala/algebra/number/NRoot.scala
@@ -19,21 +19,21 @@ import scala.{specialized => sp}
  * ideal. So, do not count on `ArithmeticException`s to save you from
  * bad arithmetic!
  */
-trait NRoot[@sp(Double,Float,Int,Long) A] {
+trait NRoot[@sp(Double, Float, Int, Long) A] {
   def nroot(a: A, n: Int): A
   def sqrt(a: A): A = nroot(a, 2)
   def fpow(a: A, b: A): A
 }
 
 trait NRootFunctions {
-  def nroot[@sp(Double,Float,Int,Long) A](a: A, n: Int)(implicit ev: NRoot[A]): A =
+  def nroot[@sp(Double, Float, Int, Long) A](a: A, n: Int)(implicit ev: NRoot[A]): A =
     ev.nroot(a, n)
-  def sqrt[@sp(Double,Float,Int,Long) A](a: A)(implicit ev: NRoot[A]): A =
+  def sqrt[@sp(Double, Float, Int, Long) A](a: A)(implicit ev: NRoot[A]): A =
     ev.sqrt(a)
-  def fpow[@sp(Double,Float,Int,Long) A](a: A, b: A)(implicit ev: NRoot[A]): A =
+  def fpow[@sp(Double, Float, Int, Long) A](a: A, b: A)(implicit ev: NRoot[A]): A =
     ev.fpow(a, b)
 }
 
 object NRoot extends NRootFunctions {
-  @inline final def apply[@sp(Int,Long,Float,Double) A](implicit ev: NRoot[A]) = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: NRoot[A]) = ev
 }

--- a/core/src/main/scala/algebra/number/Signed.scala
+++ b/core/src/main/scala/algebra/number/Signed.scala
@@ -9,7 +9,7 @@ import scala.{ specialized => sp }
  * A trait for things that have some notion of sign and the ability to
  * ensure something has a non-negative sign.
  */
-trait Signed[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
+trait Signed[@sp(Int, Long, Float, Double) A] extends Any {
 
   /**
    * Return a's sign:
@@ -40,25 +40,25 @@ trait Signed[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
 }
 
 trait SignedFunctions {
-  def sign[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Sign =
+  def sign[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Sign =
     ev.sign(a)
-  def signum[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Int =
+  def signum[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Int =
     ev.signum(a)
-  def abs[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): A =
+  def abs[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): A =
     ev.abs(a)
 
-  def isSignPositive[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignPositive[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignPositive(a)
-  def isSignZero[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignZero[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignZero(a)
-  def isSignNegative[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignNegative[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignNegative(a)
 
-  def isSignNonPositive[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignNonPositive[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignNonPositive(a)
-  def isSignNonZero[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignNonZero[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignNonZero(a)
-  def isSignNonNegative[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignNonNegative[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignNonNegative(a)
 }
 

--- a/core/src/main/scala/algebra/ring/Additive.scala
+++ b/core/src/main/scala/algebra/ring/Additive.scala
@@ -4,7 +4,7 @@ package ring
 import scala.{ specialized => sp }
 import scala.annotation.tailrec
 
-trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Serializable {
+trait AdditiveSemigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
   def additive: Semigroup[A] = new Semigroup[A] {
     def combine(x: A, y: A): A = plus(x, y)
   }
@@ -35,14 +35,14 @@ trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends An
     as.reduceOption(plus)
 }
 
-trait AdditiveCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
+trait AdditiveCommutativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
   override def additive: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
     def combine(x: A, y: A): A = plus(x, y)
   }
   override def hasCommutativeAddition: Boolean = true
 }
 
-trait AdditiveMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
+trait AdditiveMonoid[@sp(Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
   override def additive: Monoid[A] = new Monoid[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
@@ -67,14 +67,14 @@ trait AdditiveMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any w
     as.foldLeft(zero)(plus)
 }
 
-trait AdditiveCommutativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with AdditiveCommutativeSemigroup[A] {
+trait AdditiveCommutativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with AdditiveCommutativeSemigroup[A] {
   override def additive: CommutativeMonoid[A] = new CommutativeMonoid[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
   }
 }
 
-trait AdditiveGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] {
+trait AdditiveGroup[@sp(Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] {
   override def additive: Group[A] = new Group[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
@@ -92,7 +92,7 @@ trait AdditiveGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any wi
     else positiveSumN(negate(a), -n)
 }
 
-trait AdditiveCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveGroup[A] with AdditiveCommutativeMonoid[A] {
+trait AdditiveCommutativeGroup[@sp(Int, Long, Float, Double) A] extends Any with AdditiveGroup[A] with AdditiveCommutativeMonoid[A] {
   override def additive: CommutativeGroup[A] = new CommutativeGroup[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
@@ -102,31 +102,31 @@ trait AdditiveCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] ext
 }
 
 trait AdditiveSemigroupFunctions {
-  def plus[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveSemigroup[A]): A =
+  def plus[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveSemigroup[A]): A =
     ev.plus(x, y)
 
-  def sumN[@sp(Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: AdditiveSemigroup[A]): A =
+  def sumN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: AdditiveSemigroup[A]): A =
     ev.sumN(a, n)
 
-  def trySum[@sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveSemigroup[A]): Option[A] =
+  def trySum[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveSemigroup[A]): Option[A] =
     ev.trySum(as)
 }
 
 trait AdditiveMonoidFunctions extends AdditiveSemigroupFunctions {
-  def zero[@sp(Byte, Short, Int, Long, Float, Double) A](implicit ev: AdditiveMonoid[A]): A =
+  def zero[@sp(Int, Long, Float, Double) A](implicit ev: AdditiveMonoid[A]): A =
     ev.zero
 
-  def isZero[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev0: AdditiveMonoid[A], ev1: Eq[A]): Boolean =
+  def isZero[@sp(Int, Long, Float, Double) A](a: A)(implicit ev0: AdditiveMonoid[A], ev1: Eq[A]): Boolean =
     ev0.isZero(a)
 
-  def sum[@sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveMonoid[A]): A =
+  def sum[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveMonoid[A]): A =
     ev.sum(as)
 }
 
 trait AdditiveGroupFunctions extends AdditiveMonoidFunctions {
-  def negate[@sp(Byte, Short, Int, Long, Float, Double) A](x: A)(implicit ev: AdditiveGroup[A]): A =
+  def negate[@sp(Int, Long, Float, Double) A](x: A)(implicit ev: AdditiveGroup[A]): A =
     ev.negate(x)
-  def minus[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveGroup[A]): A =
+  def minus[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveGroup[A]): A =
     ev.minus(x, y)
 }
 

--- a/core/src/main/scala/algebra/ring/CommutativeRig.scala
+++ b/core/src/main/scala/algebra/ring/CommutativeRig.scala
@@ -6,7 +6,7 @@ import scala.{specialized => sp}
 /**
  * CommutativeRig is a Rig that is commutative under multiplication.
  */
-trait CommutativeRig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with MultiplicativeCommutativeMonoid[A]
+trait CommutativeRig[@sp(Int, Long, Float, Double) A] extends Any with Rig[A] with MultiplicativeCommutativeMonoid[A]
 
 object CommutativeRig extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit r: CommutativeRig[A]): CommutativeRig[A] = r

--- a/core/src/main/scala/algebra/ring/CommutativeRing.scala
+++ b/core/src/main/scala/algebra/ring/CommutativeRing.scala
@@ -6,7 +6,7 @@ import scala.{specialized => sp}
 /**
  * CommutativeRing is a Ring that is commutative under multiplication.
  */
-trait CommutativeRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Ring[A] with CommutativeRig[A]
+trait CommutativeRing[@sp(Int, Long, Float, Double) A] extends Any with Ring[A] with CommutativeRig[A]
 
 object CommutativeRing extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit r: CommutativeRing[A]): CommutativeRing[A] = r

--- a/core/src/main/scala/algebra/ring/EuclideanRing.scala
+++ b/core/src/main/scala/algebra/ring/EuclideanRing.scala
@@ -22,18 +22,18 @@ import scala.{specialized => sp}
  * This type does not provide access to the Euclidean function, but
  * only provides the quot, mod, and quotmod operators.
  */
-trait EuclideanRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with CommutativeRing[A] {
+trait EuclideanRing[@sp(Int, Long, Float, Double) A] extends Any with CommutativeRing[A] {
   def mod(a: A, b: A): A
   def quot(a: A, b: A): A
   def quotmod(a: A, b: A): (A, A) = (quot(a, b), mod(a, b))
 }
 
 trait EuclideanRingFunctions extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
-  def quot[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
+  def quot[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
     ev.quot(x, y)
-  def mod[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
+  def mod[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
     ev.mod(x, y)
-  def quotmod[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): (A, A) =
+  def quotmod[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): (A, A) =
     ev.quotmod(x, y)
 }
 

--- a/core/src/main/scala/algebra/ring/Field.scala
+++ b/core/src/main/scala/algebra/ring/Field.scala
@@ -6,7 +6,7 @@ import scala.{ specialized => sp }
 import java.lang.Double.{ isInfinite, isNaN, doubleToLongBits }
 import java.lang.Long.{ numberOfTrailingZeros }
 
-trait Field[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with EuclideanRing[A] with MultiplicativeCommutativeGroup[A] {
+trait Field[@sp(Int, Long, Float, Double) A] extends Any with EuclideanRing[A] with MultiplicativeCommutativeGroup[A] {
 
   /**
    * This is implemented in terms of basic Field ops. However, this is
@@ -42,7 +42,7 @@ trait Field[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Eucli
 }
 
 trait FieldFunctions extends EuclideanRingFunctions with MultiplicativeGroupFunctions {
-  def fromDouble[@sp(Byte, Short, Int, Long, Float, Double) A](n: Double)(implicit ev: Field[A]): A =
+  def fromDouble[@sp(Int, Long, Float, Double) A](n: Double)(implicit ev: Field[A]): A =
     ev.fromDouble(n)
 }
 

--- a/core/src/main/scala/algebra/ring/Multiplicative.scala
+++ b/core/src/main/scala/algebra/ring/Multiplicative.scala
@@ -4,7 +4,7 @@ package ring
 import scala.{ specialized => sp }
 import scala.annotation.tailrec
 
-trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Serializable {
+trait MultiplicativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
   def multiplicative: Semigroup[A] =
     new Semigroup[A] {
       def combine(x: A, y: A): A = times(x, y)
@@ -36,14 +36,14 @@ trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] exte
     as.reduceOption(times)
 }
 
-trait MultiplicativeCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
+trait MultiplicativeCommutativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
   override def hasCommutativeMultiplication: Boolean = false
   override def multiplicative: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
     def combine(x: A, y: A): A = times(x, y)
   }
 }
 
-trait MultiplicativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
+trait MultiplicativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
   override def multiplicative: Monoid[A] = new Monoid[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
@@ -68,14 +68,14 @@ trait MultiplicativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends
     as.foldLeft(one)(times)
 }
 
-trait MultiplicativeCommutativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] with MultiplicativeCommutativeSemigroup[A] {
+trait MultiplicativeCommutativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] with MultiplicativeCommutativeSemigroup[A] {
   override def multiplicative: CommutativeMonoid[A] = new CommutativeMonoid[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
   }
 }
 
-trait MultiplicativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] {
+trait MultiplicativeGroup[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] {
   override def multiplicative: Group[A] = new Group[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
@@ -93,7 +93,7 @@ trait MultiplicativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends 
     else positivePow(reciprocal(a), -n)
 }
 
-trait MultiplicativeCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeGroup[A] with MultiplicativeCommutativeMonoid[A] {
+trait MultiplicativeCommutativeGroup[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeGroup[A] with MultiplicativeCommutativeMonoid[A] {
   override def multiplicative: CommutativeGroup[A] = new CommutativeGroup[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
@@ -103,30 +103,30 @@ trait MultiplicativeCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) 
 }
 
 trait MultiplicativeSemigroupFunctions {
-  def times[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeSemigroup[A]): A =
+  def times[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeSemigroup[A]): A =
     ev.times(x, y)
-  def pow[@sp(Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: MultiplicativeSemigroup[A]): A =
+  def pow[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: MultiplicativeSemigroup[A]): A =
     ev.pow(a, n)
 
-  def tryProduct[@sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeSemigroup[A]): Option[A] =
+  def tryProduct[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeSemigroup[A]): Option[A] =
     ev.tryProduct(as)
 }
 
 trait MultiplicativeMonoidFunctions extends MultiplicativeSemigroupFunctions {
-  def one[@sp(Byte, Short, Int, Long, Float, Double) A](implicit ev: MultiplicativeMonoid[A]): A =
+  def one[@sp(Int, Long, Float, Double) A](implicit ev: MultiplicativeMonoid[A]): A =
     ev.one
 
-  def isOne[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev0: MultiplicativeMonoid[A], ev1: Eq[A]): Boolean =
+  def isOne[@sp(Int, Long, Float, Double) A](a: A)(implicit ev0: MultiplicativeMonoid[A], ev1: Eq[A]): Boolean =
     ev0.isOne(a)
 
-  def product[@sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeMonoid[A]): A =
+  def product[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeMonoid[A]): A =
     ev.product(as)
 }
 
 trait MultiplicativeGroupFunctions extends MultiplicativeMonoidFunctions {
-  def reciprocal[@sp(Byte, Short, Int, Long, Float, Double) A](x: A)(implicit ev: MultiplicativeGroup[A]): A =
+  def reciprocal[@sp(Int, Long, Float, Double) A](x: A)(implicit ev: MultiplicativeGroup[A]): A =
     ev.reciprocal(x)
-  def div[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeGroup[A]): A =
+  def div[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeGroup[A]): A =
     ev.div(x, y)
 }
 

--- a/core/src/main/scala/algebra/ring/Rig.scala
+++ b/core/src/main/scala/algebra/ring/Rig.scala
@@ -16,7 +16,7 @@ import scala.{specialized => sp}
 
  * Mnemonic: "Rig is a Ring without 'N'egation."
  */
-trait Rig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with MultiplicativeMonoid[A]
+trait Rig[@sp(Int, Long, Float, Double) A] extends Any with Semiring[A] with MultiplicativeMonoid[A]
 
 object Rig extends AdditiveMonoidFunctions with MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit ev: Rig[A]): Rig[A] = ev

--- a/core/src/main/scala/algebra/ring/Ring.scala
+++ b/core/src/main/scala/algebra/ring/Ring.scala
@@ -16,7 +16,7 @@ import scala.{specialized => sp}
  * possible, these methods should be overridden by more efficient
  * implementations.
  */
-trait Ring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] {
+trait Ring[@sp(Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] {
 
   /**
    * Convert the given integer to an instance of A.
@@ -33,7 +33,7 @@ trait Ring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A]
 }
 
 trait RingFunctions {
-  def fromInt[@sp(Byte, Short, Int, Long, Float, Double) A](n: Int)(implicit ev: Ring[A]): A =
+  def fromInt[@sp(Int, Long, Float, Double) A](n: Int)(implicit ev: Ring[A]): A =
     ev.fromInt(n)
 }
 

--- a/core/src/main/scala/algebra/ring/Rng.scala
+++ b/core/src/main/scala/algebra/ring/Rng.scala
@@ -16,7 +16,7 @@ import scala.{specialized => sp}
  * 
  * Mnemonic: "Rng is a Ring without multiplicative 'I'dentity."
  */
-trait Rng[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveCommutativeGroup[A]
+trait Rng[@sp(Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveCommutativeGroup[A]
 
 object Rng extends AdditiveGroupFunctions with MultiplicativeSemigroupFunctions {
   @inline final def apply[A](implicit ev: Rng[A]): Rng[A] = ev

--- a/core/src/main/scala/algebra/ring/Semiring.scala
+++ b/core/src/main/scala/algebra/ring/Semiring.scala
@@ -17,7 +17,7 @@ import scala.{specialized => sp}
  * A Semiring with a multiplicative identity (1) is a Rig.
  * A Semiring with both of those is a Ring.
  */
-trait Semiring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveCommutativeMonoid[A] with MultiplicativeSemigroup[A]
+trait Semiring[@sp(Int, Long, Float, Double) A] extends Any with AdditiveCommutativeMonoid[A] with MultiplicativeSemigroup[A]
 
 object Semiring extends AdditiveMonoidFunctions with MultiplicativeSemigroupFunctions {
   @inline final def apply[A](implicit ev: Semiring[A]): Semiring[A] = ev


### PR DESCRIPTION
The only places where we still specialize on these types is in
Eq/PartialOrder/Order, where we specialize on everything.
This is because these type classes have much wider usage, and
also because it's likely that users will want to define instances
for case classes and other compound types which might want to
make use of specialized instances for Char, Byte, etc.

Resolves #24.