### PR TITLE
Remove isCommutative/hasCommutative

### DIFF
--- a/core/src/main/scala/algebra/CommutativeSemigroup.scala
+++ b/core/src/main/scala/algebra/CommutativeSemigroup.scala
@@ -4,16 +4,10 @@ import scala.{ specialized => sp }
 
 /**
  * CommutativeSemigroup represents a commutative semigroup.
- * 
+ *
  * A semigroup is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeSemigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
-
-  /**
-   * CommutativeSemigroup is guaranteed to be commutative.
-   */
-  override def isCommutative: Boolean = true
-}
+trait CommutativeSemigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A]
 
 object CommutativeSemigroup extends SemigroupFunctions {
 
@@ -25,7 +19,7 @@ object CommutativeSemigroup extends SemigroupFunctions {
   /**
    * This method converts an additive instance into a generic
    * instance.
-   * 
+   *
    * Given an implicit `AdditiveCommutativeSemigroup[A]`, this method
    * returns a `CommutativeSemigroup[A]`.
    */
@@ -35,7 +29,7 @@ object CommutativeSemigroup extends SemigroupFunctions {
   /**
    * This method converts a multiplicative instance into a generic
    * instance.
-   * 
+   *
    * Given an implicit `MultiplicativeCommutativeSemigroup[A]`, this
    * method returns a `CommutativeSemigroup[A]`.
    */

--- a/core/src/main/scala/algebra/Semigroup.scala
+++ b/core/src/main/scala/algebra/Semigroup.scala
@@ -14,13 +14,6 @@ trait Semigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends A
   def combine(x: A, y: A): A
 
   /**
-   * Whether or not this particular Semigroup is commutative.
-   *
-   * For guaranteed commutativity, see CommutativeSemigroup.
-   */
-  def isCommutative: Boolean = false
-
-  /**
    * Return `a` combined with itself `n` times.
    */
   def combineN(a: A, n: Int): A =
@@ -41,7 +34,7 @@ trait Semigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends A
 
   /**
    * Given a sequence of `as`, combine them and return the total.
-   * 
+   *
    * If the sequence is empty, returns None. Otherwise, returns Some(total).
    */
   def combineAllOption(as: TraversableOnce[A]): Option[A] =
@@ -57,6 +50,18 @@ trait SemigroupFunctions {
       case Some(x) => ev.combine(x, y)
       case None => y
     }
+
+  def maybeCombine[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, oy: Option[A])(implicit ev: Semigroup[A]): A =
+    oy match {
+      case Some(y) => ev.combine(x, y)
+      case None => x
+    }
+
+  def isCommutative[A](implicit ev: Semigroup[A]): Boolean =
+    ev.isInstanceOf[CommutativeSemigroup[_]]
+
+  def isIdempotent[A](implicit ev: Semigroup[A]): Boolean =
+    ev.isInstanceOf[Band[_]]
 
   def combineN[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: Semigroup[A]): A =
     ev.combineN(a, n)
@@ -75,17 +80,18 @@ object Semigroup extends SemigroupFunctions {
   /**
    * This method converts an additive instance into a generic
    * instance.
-   * 
+   *
    * Given an implicit `AdditiveSemigroup[A]`, this method returns a
    * `Semigroup[A]`.
    */
   @inline final def additive[A](implicit ev: ring.AdditiveSemigroup[A]): Semigroup[A] =
     ev.additive
 
+
   /**
    * This method converts an multiplicative instance into a generic
    * instance.
-   * 
+   *
    * Given an implicit `MultiplicativeSemigroup[A]`, this method
    * returns a `Semigroup[A]`.
    */

--- a/core/src/main/scala/algebra/ring/Additive.scala
+++ b/core/src/main/scala/algebra/ring/Additive.scala
@@ -11,8 +11,6 @@ trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends An
 
   def plus(x: A, y: A): A
 
-  def hasCommutativeAddition: Boolean = false
-
   def sumN(a: A, n: Int): A =
     if (n > 0) positiveSumN(a, n)
     else throw new IllegalArgumentException("Illegal non-positive exponent to sumN: %s" format n)
@@ -28,7 +26,7 @@ trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends An
 
   /**
    * Given a sequence of `as`, combine them and return the total.
-   * 
+   *
    * If the sequence is empty, returns None. Otherwise, returns Some(total).
    */
   def trySum(as: TraversableOnce[A]): Option[A] =
@@ -39,7 +37,6 @@ trait AdditiveCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A]
   override def additive: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
     def combine(x: A, y: A): A = plus(x, y)
   }
-  override def hasCommutativeAddition: Boolean = true
 }
 
 trait AdditiveMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
@@ -102,6 +99,9 @@ trait AdditiveCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] ext
 }
 
 trait AdditiveSemigroupFunctions {
+  def isCommutative[A](implicit ev: AdditiveSemigroup[A]): Boolean =
+    ev.isInstanceOf[AdditiveCommutativeSemigroup[_]]
+
   def plus[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveSemigroup[A]): A =
     ev.plus(x, y)
 
@@ -133,23 +133,23 @@ trait AdditiveGroupFunctions extends AdditiveMonoidFunctions {
 object AdditiveSemigroup extends AdditiveSemigroupFunctions {
   @inline final def apply[A](implicit ev: AdditiveSemigroup[A]): AdditiveSemigroup[A] = ev
 }
-  
+
 object AdditiveCommutativeSemigroup extends AdditiveSemigroupFunctions {
   @inline final def apply[A](implicit ev: AdditiveCommutativeSemigroup[A]): AdditiveCommutativeSemigroup[A] = ev
 }
-  
+
 object AdditiveMonoid extends AdditiveMonoidFunctions {
   @inline final def apply[A](implicit ev: AdditiveMonoid[A]): AdditiveMonoid[A] = ev
 }
-  
+
 object AdditiveCommutativeMonoid extends AdditiveMonoidFunctions {
   @inline final def apply[A](implicit ev: AdditiveCommutativeMonoid[A]): AdditiveCommutativeMonoid[A] = ev
 }
-  
+
 object AdditiveGroup extends AdditiveGroupFunctions {
   @inline final def apply[A](implicit ev: AdditiveGroup[A]): AdditiveGroup[A] = ev
 }
-  
+
 object AdditiveCommutativeGroup extends AdditiveGroupFunctions {
   @inline final def apply[A](implicit ev: AdditiveCommutativeGroup[A]): AdditiveCommutativeGroup[A] = ev
 }

--- a/core/src/main/scala/algebra/ring/Multiplicative.scala
+++ b/core/src/main/scala/algebra/ring/Multiplicative.scala
@@ -12,8 +12,6 @@ trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] exte
 
   def times(x: A, y: A): A
 
-  def hasCommutativeMultiplication: Boolean = false
-
   def pow(a: A, n: Int): A =
     if (n > 0) positivePow(a, n)
     else throw new IllegalArgumentException("Illegal non-positive exponent to pow: %s" format n)
@@ -29,7 +27,7 @@ trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] exte
 
   /**
    * Given a sequence of `as`, combine them and return the total.
-   * 
+   *
    * If the sequence is empty, returns None. Otherwise, returns Some(total).
    */
   def tryProduct(as: TraversableOnce[A]): Option[A] =
@@ -37,7 +35,6 @@ trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] exte
 }
 
 trait MultiplicativeCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
-  override def hasCommutativeMultiplication: Boolean = false
   override def multiplicative: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
     def combine(x: A, y: A): A = times(x, y)
   }
@@ -103,6 +100,9 @@ trait MultiplicativeCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) 
 }
 
 trait MultiplicativeSemigroupFunctions {
+  def isCommutative[A](implicit ev: MultiplicativeSemigroup[A]): Boolean =
+    ev.isInstanceOf[MultiplicativeCommutativeSemigroup[A]]
+
   def times[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeSemigroup[A]): A =
     ev.times(x, y)
   def pow[@sp(Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: MultiplicativeSemigroup[A]): A =
@@ -133,23 +133,23 @@ trait MultiplicativeGroupFunctions extends MultiplicativeMonoidFunctions {
 object MultiplicativeSemigroup extends MultiplicativeSemigroupFunctions {
   @inline final def apply[A](implicit ev: MultiplicativeSemigroup[A]): MultiplicativeSemigroup[A] = ev
 }
-  
+
 object MultiplicativeCommutativeSemigroup extends MultiplicativeSemigroupFunctions {
   @inline final def apply[A](implicit ev: MultiplicativeCommutativeSemigroup[A]): MultiplicativeCommutativeSemigroup[A] = ev
 }
-  
+
 object MultiplicativeMonoid extends MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit ev: MultiplicativeMonoid[A]): MultiplicativeMonoid[A] = ev
 }
-  
+
 object MultiplicativeCommutativeMonoid extends MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit ev: MultiplicativeCommutativeMonoid[A]): MultiplicativeCommutativeMonoid[A] = ev
 }
-  
+
 object MultiplicativeGroup extends MultiplicativeGroupFunctions {
   @inline final def apply[A](implicit ev: MultiplicativeGroup[A]): MultiplicativeGroup[A] = ev
 }
-  
+
 object MultiplicativeCommutativeGroup extends MultiplicativeGroupFunctions {
   @inline final def apply[A](implicit ev: MultiplicativeCommutativeGroup[A]): MultiplicativeCommutativeGroup[A] = ev
 }


### PR DESCRIPTION
My argument here is that we have two ways of specifying commutativity: 1) in the type system, 2) with a method on an instance. There is the possibility there could be badly behaved instances that don't agree with these two. Moreover, it just seems more elegant to have one way.

This replaces the methods on the instances with methods on the objects that check isInstanceOf. All the old use cases are supported, but with a new method.

In Spire, you could implement you accessors in the same way if you are wrapping an Algebra object as a Spire object, so I don't think you'll lose anything.