### PR TITLE
Add tests for isCommutative/isIdempotent

### DIFF
--- a/laws/src/main/scala/algebra/laws/GroupLaws.scala
+++ b/laws/src/main/scala/algebra/laws/GroupLaws.scala
@@ -31,16 +31,23 @@ trait GroupLaws[A] extends Laws {
     Rules.repeat2("combineN", "|+|")(A.combineN)(A.combine)
   )
 
+  def band(implicit A: Band[A]) = new GroupProperties(
+    name = "band",
+    parents = List(semigroup),
+    Rules.idempotence(A.combine),
+    "isIdempotent" -> Semigroup.isIdempotent[A]
+  )
+
   def commutativeSemigroup(implicit A: CommutativeSemigroup[A]) = new GroupProperties(
     name = "commutative semigroup",
     parents = List(semigroup),
-    Rules.commutative(A.combine)
+    Rules.commutative(A.combine),
+    "isCommutative" -> Semigroup.isCommutative[A]
   )
 
   def semilattice(implicit A: Semilattice[A]) = new GroupProperties(
     name = "semilattice",
-    parents = List(commutativeSemigroup),
-    Rules.idempotence(A.combine)
+    parents = List(band, commutativeSemigroup)
   )
 
   def monoid(implicit A: Monoid[A]) = new GroupProperties(

--- a/laws/src/main/scala/algebra/laws/LatticeLaws.scala
+++ b/laws/src/main/scala/algebra/laws/LatticeLaws.scala
@@ -20,19 +20,6 @@ trait LatticeLaws[A] extends Laws {
   implicit def Equ: Eq[A]
   implicit def Arb: Arbitrary[A]
 
-  def band(implicit A: Band[A]) = new LatticeProperties(
-    name = "band",
-    parents = Nil,
-    Rules.associativity(A.combine),
-    Rules.idempotence(A.combine)
-  )
-
-  def semilattice(implicit A: Semilattice[A]) = new LatticeProperties(
-    name = "semilattice",
-    parents = List(band),
-    Rules.commutative(A.combine)
-  )
-
   def joinSemilattice(implicit A: JoinSemilattice[A]) = new LatticeProperties(
     name = "joinSemilattice",
     parents = Nil,

--- a/laws/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/src/test/scala/algebra/laws/LawTests.scala
@@ -51,6 +51,6 @@ class LawTests extends FunSuite with Discipline {
     implicit val band = new Band[(Int, Int)] {
       def combine(a: (Int, Int), b: (Int, Int)) = (a._1, b._2)
     }
-    checkAll("(Int, Int) Band", LatticeLaws[(Int, Int)].band)
+    checkAll("(Int, Int) Band", GroupLaws[(Int, Int)].band)
   }
 }


### PR DESCRIPTION
This also fixes duplicated semilattice tests by moving band and semilattice into GroupLaws.

On a side note, I'm not sure I see why we have XProperties rather than just some kind of general Properties instance. It means you can't compose inside LatticeLaws with GroupLaws. It feels a bit ad-hoc now since it is not clear where semilattice or band should go in the current picture.

I don't think it is critical, as it is just polishing the test code, but I thought I would mention my anxiety with my supportive colleagues.