### PR TITLE
Refactor laws to use bases correctly

### DIFF
--- a/laws/src/main/scala/algebra/laws/GroupLaws.scala
+++ b/laws/src/main/scala/algebra/laws/GroupLaws.scala
@@ -31,6 +31,13 @@ trait GroupLaws[A] extends Laws {
     Rules.repeat2("combineN", "|+|")(A.combineN)(A.combine)
   )
 
+  def band(implicit A: Band[A]) = new GroupProperties(
+    name = "band",
+    parents = List(semigroup),
+    Rules.idempotence(A.combine),
+    "isIdempotent" -> Semigroup.isIdempotent[A]
+  )
+
   def commutativeSemigroup(implicit A: CommutativeSemigroup[A]) = new GroupProperties(
     name = "commutative semigroup",
     parents = List(semigroup),
@@ -39,8 +46,7 @@ trait GroupLaws[A] extends Laws {
 
   def semilattice(implicit A: Semilattice[A]) = new GroupProperties(
     name = "semilattice",
-    parents = List(commutativeSemigroup),
-    Rules.idempotence(A.combine)
+    parents = List(band, commutativeSemigroup)
   )
 
   def monoid(implicit A: Monoid[A]) = new GroupProperties(
@@ -133,4 +139,5 @@ trait GroupLaws[A] extends Laws {
     val name = base.name
     val bases = List("base" -> base)
   }
+
 }

--- a/laws/src/main/scala/algebra/laws/LatticePartialOrderLaws.scala
+++ b/laws/src/main/scala/algebra/laws/LatticePartialOrderLaws.scala
@@ -25,8 +25,7 @@ trait LatticePartialOrderLaws[A] extends Laws {
   def joinSemilatticePartialOrder(implicit A: JoinSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "joinSemilatticePartialOrder",
     parents = Seq.empty,
-    bases = Seq("order" -> OrderLaws[A].partialOrder, "lattice" -> LatticeLaws[A].joinSemilattice),
-    "join.lteqv" -> forAll { (x: A, y: A) =>
+    "join+lteqv" -> forAll { (x: A, y: A) =>
       P.lteqv(x, y) ?== P.eqv(y, A.join(x, y))
     }
   )
@@ -34,54 +33,49 @@ trait LatticePartialOrderLaws[A] extends Laws {
   def meetSemilatticePartialOrder(implicit A: MeetSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "meetSemilatticePartialOrder",
     parents = Seq.empty,
-    bases = Seq("order" -> OrderLaws[A].partialOrder, "lattice" -> LatticeLaws[A].meetSemilattice),
-    "meet.lteqv" -> forAll { (x: A, y: A) =>
+    "meet+lteqv" -> forAll { (x: A, y: A) =>
       P.lteqv(x, y) ?== P.eqv(x, A.meet(x, y))
     }
   )
 
   def latticePartialOrder(implicit A: Lattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "latticePartialOrder",
-    parents = Seq(joinSemilatticePartialOrder, meetSemilatticePartialOrder),
-    bases = Seq.empty
+    parents = Seq(joinSemilatticePartialOrder, meetSemilatticePartialOrder)
   )
 
   def boundedJoinSemilatticePartialOrder(implicit A: BoundedJoinSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedJoinSemilatticePartialOrder",
     parents = Seq(joinSemilatticePartialOrder),
-    bases = Seq("lattice" -> LatticeLaws[A].boundedJoinSemilattice),
-    "lteqv.zero" -> forAll { (x: A) => A.zero ?<= x }
+    "lteqv+zero" -> forAll { (x: A) => A.zero ?<= x }
   )
 
   def boundedMeetSemilatticePartialOrder(implicit A: BoundedMeetSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedMeetSemilatticePartialOrder",
     parents = Seq(meetSemilatticePartialOrder),
-    bases = Seq("lattice" -> LatticeLaws[A].boundedMeetSemilattice),
-    "lteqv.one" -> forAll { (x: A) => x ?<= A.one }
+    "lteqv+one" -> forAll { (x: A) => x ?<= A.one }
   )
 
   def boundedBelowLatticePartialOrder(implicit A: Lattice[A] with BoundedJoinSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedBelowLatticePartialOrder",
-    parents = Seq(boundedJoinSemilatticePartialOrder, latticePartialOrder),
-    bases = Seq("lattice" -> LatticeLaws[A].boundedBelowLattice)
+    parents = Seq(boundedJoinSemilatticePartialOrder, latticePartialOrder)
   )
 
   def boundedAboveLatticePartialOrder(implicit A: Lattice[A] with BoundedMeetSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedAboveLatticePartialOrder",
-    parents = Seq(boundedMeetSemilatticePartialOrder, latticePartialOrder),
-    bases = Seq("lattice" -> LatticeLaws[A].boundedAboveLattice)
+    parents = Seq(boundedMeetSemilatticePartialOrder, latticePartialOrder)
   )
   
   def boundedLatticePartialOrder(implicit A: BoundedLattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedLatticePartialOrder",
-    parents = Seq(boundedJoinSemilatticePartialOrder, boundedMeetSemilatticePartialOrder),
-    bases = Seq("lattice" -> LatticeLaws[A].boundedLattice)
+    parents = Seq(boundedJoinSemilatticePartialOrder, boundedMeetSemilatticePartialOrder)
   )
   
   class LatticePartialOrderProperties(
     val name: String,
     val parents: Seq[LatticePartialOrderProperties],
-    val bases: Seq[(String, Laws#RuleSet)],
     val props: (String, Prop)*
-  ) extends RuleSet
+  ) extends RuleSet {
+    def bases = Nil
+  }
+
 }

--- a/laws/src/main/scala/algebra/laws/LogicLaws.scala
+++ b/laws/src/main/scala/algebra/laws/LogicLaws.scala
@@ -15,63 +15,62 @@ object LogicLaws {
   }
 }
 
-trait LogicLaws[A] extends Laws {
+trait LogicLaws[A] extends LatticeLaws[A] {
 
-  implicit def Equ: Eq[A]
-  implicit def Arb: Arbitrary[A]
+  def heyting(implicit A: Heyting[A]) = new LogicProperties(
+    name = "heyting",
+    parent = None,
+    ll = boundedLattice,
 
-  def heyting(implicit A: Heyting[A]) =
-    new LogicProperties(
-      name = "heyting",
-      parents = Nil,
-      bases = Seq("boundedLattice" -> LatticeLaws[A].boundedLattice),
+    Rules.distributive(A.or)(A.and),
 
-      Rules.distributive(A.or)(A.and),
+    "consistent" -> forAll { (x: A) => A.and(x, A.complement(x)) ?== A.zero },
+    "¬x = (x → 0)" -> forAll { (x: A) => A.complement(x) ?== A.imp(x, A.zero) },
+    "x → x = 1" -> forAll { (x: A) => A.imp(x, x) ?== A.one },
 
-      "consistent" -> forAll { (x: A) => A.and(x, A.complement(x)) ?== A.zero },
-      "¬x = (x → 0)" -> forAll { (x: A) => A.complement(x) ?== A.imp(x, A.zero) },
-      "x → x = 1" -> forAll { (x: A) => A.imp(x, x) ?== A.one },
-      
-      "if x → y and y → x then x=y" -> forAll { (x: A, y: A) =>
-        (A.imp(x, y) ?!= A.one) || (A.imp(y, x) ?!= A.one) || (x ?== y)
-      },
-      
-      "if (1 → x)=1 then x=1" -> forAll { (x: A) =>
-        (A.imp(A.one, x) ?!= A.one) || (x ?== A.one)
-      },
-      
-      "x → (y → x) = 1" -> forAll { (x: A, y: A) => A.imp(x, A.imp(y, x)) ?== A.one },
-      
-      "(x→(y→z)) → ((x→y)→(x→z)) = 1" -> forAll { (x: A, y: A, z: A) =>
-        A.imp(A.imp(x, A.imp(y, z)), A.imp(A.imp(x, y), A.imp(x, z))) ?== A.one
-      },
-      
-      "x∧y → x = 1" -> forAll { (x: A, y: A) => A.imp(A.and(x, y), x) ?== A.one },
-      "x∧y → y = 1" -> forAll { (x: A, y: A) => A.imp(A.and(x, y), y) ?== A.one },
-      "x → y → (x∧y) = 1" -> forAll { (x: A, y: A) => A.imp(x, A.imp(y, A.and(x, y))) ?== A.one },
-      
-      "x → x∨y" -> forAll { (x: A, y: A) => A.imp(x, A.or(x, y)) ?== A.one },
-      "y → x∨y" -> forAll { (x: A, y: A) => A.imp(y, A.or(x, y)) ?== A.one },
-      
-      "(x → z) → ((y → z) → ((x | y) → z)) = 1" -> forAll { (x: A, y: A, z: A) =>
-        A.imp(A.imp(x, z), A.imp(A.imp(y, z), A.imp(A.or(x, y), z))) ?== A.one
-      },
-      
-      "(0 → x) = 1" -> forAll { (x: A) => A.imp(A.zero, x) ?== A.one }
-    )
+    "if x → y and y → x then x=y" -> forAll { (x: A, y: A) =>
+      (A.imp(x, y) ?!= A.one) || (A.imp(y, x) ?!= A.one) || (x ?== y)
+    },
 
-  def bool(implicit A: Bool[A]) =
-    new LogicProperties(
-      name = "bool",
-      parents = Seq(heyting),
-      bases = Seq.empty,
-      "excluded middle" -> forAll { (x: A) => A.or(x, A.complement(x)) ?== A.one }
-    )
+    "if (1 → x)=1 then x=1" -> forAll { (x: A) =>
+      (A.imp(A.one, x) ?!= A.one) || (x ?== A.one)
+    },
+
+    "x → (y → x) = 1" -> forAll { (x: A, y: A) => A.imp(x, A.imp(y, x)) ?== A.one },
+
+    "(x→(y→z)) → ((x→y)→(x→z)) = 1" -> forAll { (x: A, y: A, z: A) =>
+      A.imp(A.imp(x, A.imp(y, z)), A.imp(A.imp(x, y), A.imp(x, z))) ?== A.one
+    },
+
+    "x∧y → x = 1" -> forAll { (x: A, y: A) => A.imp(A.and(x, y), x) ?== A.one },
+    "x∧y → y = 1" -> forAll { (x: A, y: A) => A.imp(A.and(x, y), y) ?== A.one },
+    "x → y → (x∧y) = 1" -> forAll { (x: A, y: A) => A.imp(x, A.imp(y, A.and(x, y))) ?== A.one },
+
+    "x → x∨y" -> forAll { (x: A, y: A) => A.imp(x, A.or(x, y)) ?== A.one },
+    "y → x∨y" -> forAll { (x: A, y: A) => A.imp(y, A.or(x, y)) ?== A.one },
+
+    "(x → z) → ((y → z) → ((x | y) → z)) = 1" -> forAll { (x: A, y: A, z: A) =>
+      A.imp(A.imp(x, z), A.imp(A.imp(y, z), A.imp(A.or(x, y), z))) ?== A.one
+    },
+
+    "(0 → x) = 1" -> forAll { (x: A) => A.imp(A.zero, x) ?== A.one }
+  )
+
+  def bool(implicit A: Bool[A]) = new LogicProperties(
+    name = "bool",
+    parent = Some(heyting),
+    ll = boundedLattice,
+
+    "excluded middle" -> forAll { (x: A) => A.or(x, A.complement(x)) ?== A.one }
+  )
 
   class LogicProperties(
     val name: String,
-    val parents: Seq[LogicProperties],
-    val bases: Seq[(String, Laws#RuleSet)],
+    val parent: Option[LogicProperties],
+    val ll: LatticeProperties,
     val props: (String, Prop)*
-  ) extends RuleSet
+  ) extends RuleSet with HasOneParent {
+    val bases = Seq("lattice" -> ll)
+  }
+
 }

--- a/laws/src/main/scala/algebra/laws/OrderLaws.scala
+++ b/laws/src/main/scala/algebra/laws/OrderLaws.scala
@@ -54,7 +54,8 @@ trait OrderLaws[A] extends Laws {
 
   class OrderProperties(
     name: String,
-    parent: Option[OrderProperties],
+    parent: Option[RuleSet],
     props: (String, Prop)*
   ) extends DefaultRuleSet(name, parent, props: _*)
+
 }

--- a/laws/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/src/test/scala/algebra/laws/LawTests.scala
@@ -51,6 +51,6 @@ class LawTests extends FunSuite with Discipline {
     implicit val band = new Band[(Int, Int)] {
       def combine(a: (Int, Int), b: (Int, Int)) = (a._1, b._2)
     }
-    checkAll("(Int, Int) Band", LatticeLaws[(Int, Int)].band)
+    checkAll("(Int, Int) Band", GroupLaws[(Int, Int)].band)
   }
 }


### PR DESCRIPTION
Includes and supersedes #36, which suffered from a suboptimal use of bases.