### PR TITLE
Add Unit instances

### DIFF
--- a/laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -96,5 +96,9 @@ trait LawTestsBase extends FunSuite with Discipline {
     }
     checkAll("(Int, Int) Band", GroupLaws[(Int, Int)].band)
   }
+
+  laws[OrderLaws, Unit].check(_.order)
+  laws[RingLaws, Unit].check(_.rig)
+  laws[RingLaws, Unit].check(_.multiplicativeMonoid)
 }
 

--- a/laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -98,7 +98,8 @@ trait LawTestsBase extends FunSuite with Discipline {
   }
 
   laws[OrderLaws, Unit].check(_.order)
-  laws[RingLaws, Unit].check(_.rig)
+  laws[RingLaws, Unit].check(_.ring)
   laws[RingLaws, Unit].check(_.multiplicativeMonoid)
+  laws[LatticeLaws, Unit].check(_.boundedSemilattice)
 }
 

--- a/std/shared/src/main/scala/algebra/std/all.scala
+++ b/std/shared/src/main/scala/algebra/std/all.scala
@@ -17,3 +17,4 @@ package object all
     with ShortInstances
     with StringInstances
     with TupleInstances
+    with UnitInstances

--- a/std/shared/src/main/scala/algebra/std/unit.scala
+++ b/std/shared/src/main/scala/algebra/std/unit.scala
@@ -21,7 +21,7 @@ class UnitAlgebra extends Order[Unit] with CommutativeRing[Unit] with BoundedSem
   override def lteqv(x: Unit, y: Unit): Boolean = true
 
   override def min(x: Unit, y: Unit): Unit = ()
-  override def max(x: Unit, y: Unit): Unit = Unit
+  override def max(x: Unit, y: Unit): Unit = ()
 
   def zero: Unit = ()
   def one: Unit = ()

--- a/std/shared/src/main/scala/algebra/std/unit.scala
+++ b/std/shared/src/main/scala/algebra/std/unit.scala
@@ -1,16 +1,16 @@
 package algebra
 package std
 
-import algebra.ring.CommutativeRig
+import algebra.ring.CommutativeRing
 
 package object unit extends UnitInstances
 
 trait UnitInstances {
-  implicit val unitAlgebra: Order[Unit] with CommutativeRig[Unit] =
+  implicit val unitAlgebra: Order[Unit] with CommutativeRing[Unit] with BoundedSemilattice[Unit] =
     new UnitAlgebra
 }
 
-class UnitAlgebra extends Order[Unit] with CommutativeRig[Unit] {
+class UnitAlgebra extends Order[Unit] with CommutativeRing[Unit] with BoundedSemilattice[Unit] {
   def compare(x: Unit, y: Unit): Int = 0
 
   override def eqv(x: Unit, y: Unit): Boolean = true
@@ -30,6 +30,10 @@ class UnitAlgebra extends Order[Unit] with CommutativeRig[Unit] {
   override def isOne(x: Unit)(implicit ev: Eq[Unit]): Boolean = true
 
   def plus(a: Unit, b: Unit): Unit = ()
+  def negate(x: Unit): Unit = ()
   def times(a: Unit, b: Unit): Unit = ()
   override def pow(a: Unit, b: Int): Unit = ()
+
+  def empty: Unit = ()
+  def combine(x: Unit, y: Unit): Unit = ()
 }

--- a/std/shared/src/main/scala/algebra/std/unit.scala
+++ b/std/shared/src/main/scala/algebra/std/unit.scala
@@ -1,0 +1,35 @@
+package algebra
+package std
+
+import algebra.ring.CommutativeRig
+
+package object unit extends UnitInstances
+
+trait UnitInstances {
+  implicit val unitAlgebra: Order[Unit] with CommutativeRig[Unit] =
+    new UnitAlgebra
+}
+
+class UnitAlgebra extends Order[Unit] with CommutativeRig[Unit] {
+  def compare(x: Unit, y: Unit): Int = 0
+
+  override def eqv(x: Unit, y: Unit): Boolean = true
+  override def neqv(x: Unit, y: Unit): Boolean = false
+  override def gt(x: Unit, y: Unit): Boolean = false
+  override def lt(x: Unit, y: Unit): Boolean = false
+  override def gteqv(x: Unit, y: Unit): Boolean = true
+  override def lteqv(x: Unit, y: Unit): Boolean = true
+
+  override def min(x: Unit, y: Unit): Unit = ()
+  override def max(x: Unit, y: Unit): Unit = Unit
+
+  def zero: Unit = ()
+  def one: Unit = ()
+
+  override def isZero(x: Unit)(implicit ev: Eq[Unit]): Boolean = true
+  override def isOne(x: Unit)(implicit ev: Eq[Unit]): Boolean = true
+
+  def plus(a: Unit, b: Unit): Unit = ()
+  def times(a: Unit, b: Unit): Unit = ()
+  override def pow(a: Unit, b: Int): Unit = ()
+}


### PR DESCRIPTION
Mostly I wanted the `Order` instance for `Unit`. The use-case is that in
some tests we want to check if something two instances of
`Error Xor Unit` are equal, and the derived `Eq` instance for `Xor`
needs an `Eq` instance for both sides.

I have no idea whether the `CommutativeRig[Unit]` is a good idea or is
useful. It seems to be law-abiding though. Let me know if you want me to
rip it out.