### PR TITLE
Override repeatedCombineN and combineAllOption for Unit algebra

### DIFF
--- a/std/shared/src/main/scala/algebra/std/unit.scala
+++ b/std/shared/src/main/scala/algebra/std/unit.scala
@@ -36,4 +36,7 @@ class UnitAlgebra extends Order[Unit] with CommutativeRing[Unit] with BoundedSem
 
   def empty: Unit = ()
   def combine(x: Unit, y: Unit): Unit = ()
+  override protected[this] def repeatedCombineN(a: Unit, n: Int): Unit = ()
+  override def combineAllOption(as: TraversableOnce[Unit]): Option[Unit] =
+    if (as.isEmpty) None else Some(())
 }


### PR DESCRIPTION
The `combineAllOption` override is per a [suggestion](https://github.com/non/algebra/pull/87#discussion_r41585052) from @johnynek.