### PR TITLE
Fix band specialization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val aggregate = project.in(file("."))
 lazy val core = crossProject.crossType(CrossType.Pure)
   .settings(moduleName := "algebra")
   .settings(mimaDefaultSettings: _*)
-  .settings(previousArtifact := Some("org.spire-math" %% "algebra" % "0.3.1"))
+  .settings(previousArtifact := None)
   .settings(algebraSettings: _*)
   .settings(sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.gen))
 

--- a/core/src/main/scala/algebra/Band.scala
+++ b/core/src/main/scala/algebra/Band.scala
@@ -7,12 +7,12 @@ import scala.{specialized => sp}
  * Bands are semigroups whose operation
  * (i.e. combine) is also idempotent.
  */
-trait Band[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A]
+trait Band[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A]
 
 object Band {
 
   /**
    * Access an implicit `Band[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Band[A]): Band[A] = ev
+  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: Band[A]): Band[A] = ev
 }


### PR DESCRIPTION
fixes #90 

Question: should Band and Semilattice use just Int, Long? Looks like most or all of algebra.lattice does this (even though you could make a lattice of Doubles/Floats with max/min).