### PR TITLE
Fix bug in .asCommutativeRing, and ensure it is correct.

### DIFF
--- a/core/src/main/scala/algebra/lattice/Bool.scala
+++ b/core/src/main/scala/algebra/lattice/Bool.scala
@@ -37,7 +37,7 @@ trait Bool[@sp(Int, Long) A] extends Any with Heyting[A] { self =>
       def zero: A = self.zero
       def one: A = self.one
       def plus(x: A, y: A): A = self.xor(x, y)
-      def negate(x: A): A = self.complement(x)
+      def negate(x: A): A = x
       def times(x: A, y: A): A = self.and(x, y)
     }
 }

--- a/laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -41,6 +41,9 @@ trait LawTestsBase extends FunSuite with Discipline {
   laws[LogicLaws, SimpleHeyting].check(_.heyting)
   laws[LatticePartialOrderLaws, Boolean].check(_.boundedLatticePartialOrder)
 
+  // ensure that Bool[A].asCommutativeRing is valid
+  laws[RingLaws, Boolean].check(_.ring(Bool[Boolean].asCommutativeRing))
+
   laws[OrderLaws, String].check(_.order)
   laws[GroupLaws, String].check(_.monoid)
 


### PR DESCRIPTION
This commit makes sure we run our law tests on the ring
produced by Bool[Boolean].asCommutativeRing.

We might want to audit other typeclass-producing methods
to ensure that we do at least some law-checking on those
instances as well.

Review by @TomasMikula and @johnynek.