### PR TITLE
Let Ring and CommutativeRing companions extend RingFunctions.

### DIFF
--- a/core/src/main/scala/algebra/ring/BoolRing.scala
+++ b/core/src/main/scala/algebra/ring/BoolRing.scala
@@ -35,6 +35,6 @@ private[ring] class BoolFromBoolRing[A](orig: BoolRing[A]) extends GenBoolFromBo
   override def asBoolRing: BoolRing[A] = orig
 }
 
-object BoolRing extends RingFunctions {
+object BoolRing extends RingFunctions[BoolRing] {
   @inline final def apply[A](implicit r: BoolRing[A]): BoolRing[A] = r
 }

--- a/core/src/main/scala/algebra/ring/CommutativeRing.scala
+++ b/core/src/main/scala/algebra/ring/CommutativeRing.scala
@@ -8,6 +8,6 @@ import scala.{specialized => sp}
  */
 trait CommutativeRing[@sp(Int, Long, Float, Double) A] extends Any with Ring[A] with CommutativeRig[A]
 
-object CommutativeRing extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
+object CommutativeRing extends RingFunctions {
   @inline final def apply[A](implicit r: CommutativeRing[A]): CommutativeRing[A] = r
 }

--- a/core/src/main/scala/algebra/ring/CommutativeRing.scala
+++ b/core/src/main/scala/algebra/ring/CommutativeRing.scala
@@ -8,6 +8,6 @@ import scala.{specialized => sp}
  */
 trait CommutativeRing[@sp(Int, Long, Float, Double) A] extends Any with Ring[A] with CommutativeRig[A]
 
-object CommutativeRing extends RingFunctions {
+object CommutativeRing extends RingFunctions[CommutativeRing] {
   @inline final def apply[A](implicit r: CommutativeRing[A]): CommutativeRing[A] = r
 }

--- a/core/src/main/scala/algebra/ring/EuclideanRing.scala
+++ b/core/src/main/scala/algebra/ring/EuclideanRing.scala
@@ -28,7 +28,7 @@ trait EuclideanRing[@sp(Int, Long, Float, Double) A] extends Any with Commutativ
   def quotmod(a: A, b: A): (A, A) = (quot(a, b), mod(a, b))
 }
 
-trait EuclideanRingFunctions extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
+trait EuclideanRingFunctions extends RingFunctions {
   def quot[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
     ev.quot(x, y)
   def mod[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =

--- a/core/src/main/scala/algebra/ring/EuclideanRing.scala
+++ b/core/src/main/scala/algebra/ring/EuclideanRing.scala
@@ -28,15 +28,15 @@ trait EuclideanRing[@sp(Int, Long, Float, Double) A] extends Any with Commutativ
   def quotmod(a: A, b: A): (A, A) = (quot(a, b), mod(a, b))
 }
 
-trait EuclideanRingFunctions extends RingFunctions {
-  def quot[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
+trait EuclideanRingFunctions[R[T] <: EuclideanRing[T]] extends RingFunctions[R] {
+  def quot[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: R[A]): A =
     ev.quot(x, y)
-  def mod[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
+  def mod[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: R[A]): A =
     ev.mod(x, y)
-  def quotmod[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): (A, A) =
+  def quotmod[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: R[A]): (A, A) =
     ev.quotmod(x, y)
 }
 
-object EuclideanRing extends EuclideanRingFunctions {
+object EuclideanRing extends EuclideanRingFunctions[EuclideanRing] {
   @inline final def apply[A](implicit ev: EuclideanRing[A]): EuclideanRing[A] = ev
 }

--- a/core/src/main/scala/algebra/ring/Field.scala
+++ b/core/src/main/scala/algebra/ring/Field.scala
@@ -41,11 +41,11 @@ trait Field[@sp(Int, Long, Float, Double) A] extends Any with EuclideanRing[A] w
     }
 }
 
-trait FieldFunctions extends EuclideanRingFunctions with MultiplicativeGroupFunctions {
-  def fromDouble[@sp(Int, Long, Float, Double) A](n: Double)(implicit ev: Field[A]): A =
+trait FieldFunctions[F[T] <: Field[T]] extends EuclideanRingFunctions[F] with MultiplicativeGroupFunctions {
+  def fromDouble[@sp(Int, Long, Float, Double) A](n: Double)(implicit ev: F[A]): A =
     ev.fromDouble(n)
 }
 
-object Field extends FieldFunctions {
+object Field extends FieldFunctions[Field] {
   @inline final def apply[A](implicit ev: Field[A]): Field[A] = ev
 }

--- a/core/src/main/scala/algebra/ring/Ring.scala
+++ b/core/src/main/scala/algebra/ring/Ring.scala
@@ -32,11 +32,11 @@ trait Ring[@sp(Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] 
   def fromInt(n: Int): A = sumN(one, n)
 }
 
-trait RingFunctions extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
-  def fromInt[@sp(Int, Long, Float, Double) A](n: Int)(implicit ev: Ring[A]): A =
+trait RingFunctions[R[T] <: Ring[T]] extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
+  def fromInt[@sp(Int, Long, Float, Double) A](n: Int)(implicit ev: R[A]): A =
     ev.fromInt(n)
 }
 
-object Ring extends RingFunctions {
+object Ring extends RingFunctions[Ring] {
   @inline final def apply[A](implicit ev: Ring[A]): Ring[A] = ev
 }

--- a/core/src/main/scala/algebra/ring/Ring.scala
+++ b/core/src/main/scala/algebra/ring/Ring.scala
@@ -32,11 +32,11 @@ trait Ring[@sp(Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] 
   def fromInt(n: Int): A = sumN(one, n)
 }
 
-trait RingFunctions {
+trait RingFunctions extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
   def fromInt[@sp(Int, Long, Float, Double) A](n: Int)(implicit ev: Ring[A]): A =
     ev.fromInt(n)
 }
 
-object Ring extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
+object Ring extends RingFunctions {
   @inline final def apply[A](implicit ev: Ring[A]): Ring[A] = ev
 }


### PR DESCRIPTION
It seemed like an oversight that `object Ring` did not extend `RingFunctions`.