### PR TITLE
Add BoolRng and GenBool. Resolves #107.

### DIFF
--- a/core/src/main/scala/algebra/lattice/GenBool.scala
+++ b/core/src/main/scala/algebra/lattice/GenBool.scala
@@ -1,0 +1,57 @@
+package algebra
+package lattice
+
+import ring.BoolRng
+import scala.{specialized => sp}
+
+/**
+ * Generalized Boolean algebra, that is, a Boolean algebra without
+ * the top element. Generalized Boolean algebras do not (in general)
+ * have (absolute) complements, but they have ''relative complements''
+ * (see [[GenBool.without]]).
+ */
+trait GenBool[@sp(Int, Long) A] extends Any with DistributiveLattice[A] with BoundedJoinSemilattice[A] { self =>
+  def and(a: A, b: A): A
+  override def meet(a: A, b: A): A = and(a, b)
+
+  def or(a: A, b: A): A
+  override def join(a: A, b: A): A = or(a, b)
+
+  /**
+   * The operation of ''relative complement'', symbolically often denoted
+   * `a\b` (the symbol for set-theoretic difference, which is the
+   * meaning of relative complement in the lattice of sets).
+   */
+  def without(a: A, b: A): A
+
+  /**
+   * Logical exclusive or, set-theoretic symmetric difference.
+   * Defined as `a\b ∨ b\a`.
+   */
+  def xor(a: A, b: A): A = or(without(a, b), without(b, a))
+
+  /**
+   * Every generalized Boolean algebra is also a `BoolRng`, with
+   * multiplication defined as `and` and addition defined as `xor`.
+   */
+  def asBoolRing: BoolRng[A] = new BoolRngFromGenBool(self)
+}
+
+private[lattice] class BoolRngFromGenBool[@sp(Int, Long) A](orig: GenBool[A]) extends BoolRng[A] {
+  def zero: A = orig.zero
+  def plus(x: A, y: A): A = orig.xor(x, y)
+  def times(x: A, y: A): A = orig.and(x, y)
+  override def asBool: GenBool[A] = orig
+}
+
+trait GenBoolFunctions {
+  def zero[@sp(Int, Long) A](implicit ev: GenBool[A]): A = ev.zero
+  def and[@sp(Int, Long) A](x: A, y: A)(implicit ev: GenBool[A]): A = ev.and(x, y)
+  def or[@sp(Int, Long) A](x: A, y: A)(implicit ev: GenBool[A]): A = ev.or(x, y)
+  def without[@sp(Int, Long) A](x: A, y: A)(implicit ev: GenBool[A]): A = ev.without(x, y)
+  def xor[@sp(Int, Long) A](x: A, y: A)(implicit ev: GenBool[A]): A = ev.xor(x, y)
+}
+
+object GenBool extends BoolFunctions {
+  @inline final def apply[@sp(Int, Long) A](implicit ev: GenBool[A]): GenBool[A] = ev
+}

--- a/core/src/main/scala/algebra/ring/BoolRing.scala
+++ b/core/src/main/scala/algebra/ring/BoolRing.scala
@@ -11,8 +11,7 @@ import lattice.Bool
  * Every Boolean ring is equivalent to a Boolean algebra.
  * See [[BoolRing.asBool]] for details.
  */
-trait BoolRing[A] extends Any with CommutativeRing[A] { self =>
-  override final def negate(x: A): A = x
+trait BoolRing[A] extends Any with BoolRng[A] with CommutativeRing[A] { self =>
 
   /**
    * Every Boolean ring gives rise to a Boolean algebra:
@@ -26,14 +25,14 @@ trait BoolRing[A] extends Any with CommutativeRing[A] { self =>
    *
    * @see [[algebra.lattice.Bool.asBoolRing]]
    */
-  def asBool: Bool[A] = new Bool[A] {
-    def zero: A = self.zero
-    def one: A = self.one
-    def and(a: A, b: A): A = self.times(a, b)
-    def complement(a: A): A = self.plus(self.one, a)
-    def or(a: A, b: A): A = self.plus(self.plus(a, b), self.times(a, b))
-    override def asBoolRing: BoolRing[A] = self
-  }
+  override def asBool: Bool[A] = new BoolFromBoolRing(self)
+}
+
+private[ring] class BoolFromBoolRing[A](orig: BoolRing[A]) extends GenBoolFromBoolRng(orig) with Bool[A] {
+  def one: A = orig.one
+  def complement(a: A): A = orig.plus(orig.one, a)
+  override def without(a: A, b: A): A = super[GenBoolFromBoolRng].without(a, b)
+  override def asBoolRing: BoolRing[A] = orig
 }
 
 object BoolRing extends RingFunctions {

--- a/core/src/main/scala/algebra/ring/BoolRng.scala
+++ b/core/src/main/scala/algebra/ring/BoolRng.scala
@@ -1,0 +1,42 @@
+package algebra
+package ring
+
+import lattice.GenBool
+
+/**
+ * A Boolean rng is a rng whose multiplication is idempotent, that is
+ * `a⋅a = a` for all elements ''a''. This property also implies `a+a = 0`
+ * for all ''a'', and `a⋅b = b⋅a` (commutativity of multiplication).
+ *
+ * Every `BoolRng` is equivalent to [[algebra.lattice.GenBool]].
+ * See [[BoolRng.asBool]] for details.
+ */
+trait BoolRng[A] extends Any with Rng[A] { self =>
+  override final def negate(x: A): A = x
+
+  /**
+   * Every Boolean rng gives rise to a Boolean algebra without top:
+   *  - 0 is preserved;
+   *  - ring multiplication (`times`) corresponds to `and`;
+   *  - ring addition (`plus`) corresponds to `xor`;
+   *  - `a or b` is then defined as `a xor b xor (a and b)`;
+   *  - relative complement `a\b` is defined as `a xor (a and b)`.
+   *
+   * `BoolRng.asBool.asBoolRing` gives back the original `BoolRng`.
+   *
+   * @see [[algebra.lattice.GenBool.asBoolRing]]
+   */
+  def asBool: GenBool[A] = new GenBoolFromBoolRng(self)
+}
+
+private[ring] class GenBoolFromBoolRng[A](orig: BoolRng[A]) extends GenBool[A] {
+  def zero: A = orig.zero
+  def and(a: A, b: A): A = orig.times(a, b)
+  def or(a: A, b: A): A = orig.plus(orig.plus(a, b), orig.times(a, b))
+  def without(a: A, b: A): A = orig.plus(a, orig.times(a, b))
+  override def asBoolRing: BoolRng[A] = orig
+}
+
+object BoolRng extends AdditiveGroupFunctions with MultiplicativeSemigroupFunctions {
+  @inline final def apply[A](implicit r: BoolRng[A]): BoolRng[A] = r
+}

--- a/laws/shared/src/main/scala/algebra/laws/LogicLaws.scala
+++ b/laws/shared/src/main/scala/algebra/laws/LogicLaws.scala
@@ -66,10 +66,10 @@ trait LogicLaws[A] extends LatticeLaws[A] {
       meet = Some(semilattice(A.meetSemilattice))
     ),
 
-    "x∖y ∧ y = 0" -> forAll { (x: A, y: A) =>
+    """x\y ∧ y = 0""" -> forAll { (x: A, y: A) =>
       A.and(A.without(x, y), y) ?== A.zero },
 
-    "x∖y ∨ y = x ∨ y" -> forAll { (x: A, y: A) =>
+    """x\y ∨ y = x ∨ y""" -> forAll { (x: A, y: A) =>
       A.or(A.without(x, y), y) ?== A.or(x, y) }
   )
 

--- a/laws/shared/src/main/scala/algebra/laws/RingLaws.scala
+++ b/laws/shared/src/main/scala/algebra/laws/RingLaws.scala
@@ -117,6 +117,12 @@ trait RingLaws[A] extends GroupLaws[A] {
     parents = Seq(ring, commutativeRig)
   )
 
+  def boolRng(implicit A: BoolRng[A]) = RingProperties.fromParent(
+    name = "boolean rng",
+    parent = rng,
+    Rules.idempotence(A.times)
+  )
+
   def boolRing(implicit A: BoolRing[A]) = RingProperties.fromParent(
     name = "boolean ring",
     parent = commutativeRing,

--- a/laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -68,8 +68,10 @@ trait LawTestsBase extends FunSuite with Discipline {
   laws[OrderLaws, List[String]].check(_.order)
   laws[GroupLaws, List[String]].check(_.monoid)
 
-  laws[LatticeLaws, Set[Int]].check(_.distributiveLattice)
-  laws[LatticeLaws, Set[Int]].check(_.boundedJoinLattice)
+  laws[LogicLaws, Set[Byte]].check(_.generalizedBool)
+  laws[RingLaws, Set[Byte]].check(_.boolRng(setBoolRng[Byte]))
+  laws[LogicLaws, Set[Byte]]("bool-from-rng").check(_.generalizedBool(setBoolRng.asBool))
+  laws[RingLaws, Set[Byte]]("rng-from-bool").check(_.boolRng(GenBool[Set[Byte]].asBoolRing))
   laws[OrderLaws, Set[Int]].check(_.partialOrder)
   laws[RingLaws, Set[Int]].check(_.semiring)
   laws[RingLaws, Set[String]].check(_.semiring)

--- a/std/src/main/scala/algebra/std/set.scala
+++ b/std/src/main/scala/algebra/std/set.scala
@@ -1,21 +1,23 @@
 package algebra
 package std
 
-import algebra.lattice.{BoundedJoinSemilattice, DistributiveLattice}
-import algebra.ring.Semiring
+import algebra.lattice.GenBool
+import algebra.ring.{BoolRng, Semiring}
 
 package object set extends SetInstances
 
 trait SetInstances {
-  implicit def setLattice[A]: DistributiveLattice[Set[A]] with BoundedJoinSemilattice[Set[A]] = new SetLattice[A]
+  implicit def setLattice[A]: GenBool[Set[A]] = new SetLattice[A]
   implicit def setPartialOrder[A]: PartialOrder[Set[A]] = new SetPartialOrder[A]
   implicit def setSemiring[A] = new SetSemiring[A]
+  def setBoolRng[A] = new SetBoolRng[A]
 }
 
-class SetLattice[A] extends DistributiveLattice[Set[A]] with BoundedJoinSemilattice[Set[A]] {
+class SetLattice[A] extends GenBool[Set[A]] {
   def zero: Set[A] = Set.empty[A]
-  def join(lhs: Set[A], rhs: Set[A]): Set[A] = lhs.union(rhs)
-  def meet(lhs: Set[A], rhs: Set[A]): Set[A] = lhs.intersect(rhs)
+  def or(lhs: Set[A], rhs: Set[A]): Set[A] = lhs.union(rhs)
+  def and(lhs: Set[A], rhs: Set[A]): Set[A] = lhs.intersect(rhs)
+  def without(lhs: Set[A], rhs: Set[A]): Set[A] = lhs -- rhs
 }
 
 class SetPartialOrder[A] extends PartialOrder[Set[A]] {
@@ -31,5 +33,11 @@ class SetPartialOrder[A] extends PartialOrder[Set[A]] {
 class SetSemiring[A] extends Semiring[Set[A]] {
   def zero: Set[A] = Set.empty
   def plus(x: Set[A], y: Set[A]): Set[A] = x | y
+  def times(x: Set[A], y: Set[A]): Set[A] = x & y
+}
+
+class SetBoolRng[A] extends BoolRng[Set[A]] {
+  def zero: Set[A] = Set.empty
+  def plus(x: Set[A], y: Set[A]): Set[A] = (x--y) | (y--x)
   def times(x: Set[A], y: Set[A]): Set[A] = x & y
 }


### PR DESCRIPTION
This is a work in progress on topless Bool/BoolRing (#107), subject to some renaming. In this version I used the names `GenBool` for _generalized Boolean algebra_ and `without(a, b)` for `a\b` (relative complement of b with respect to a).