### PR TITLE
Pass along exception when serialization test fails

### DIFF
--- a/laws/jvm/src/main/scala/algebra/laws/Platform.scala
+++ b/laws/jvm/src/main/scala/algebra/laws/Platform.scala
@@ -4,6 +4,7 @@ package laws
 import org.scalacheck.{Arbitrary, Prop}
 import org.scalacheck.Prop._
 import Prop.{False, Proof, Result}
+import scala.util.control.NonFatal
 
 private[laws] object Platform {
 
@@ -23,8 +24,8 @@ private[laws] object Platform {
         val m2 = ois.readObject() // just ensure we can read it back
         ois.close()
         Result(status = Proof)
-      } catch { case _: Throwable =>
-        Result(status = False)
+      } catch { case NonFatal(t) =>
+        Result(status = Exception(t))
       } finally {
         oos.close()
         if (ois != null) ois.close()


### PR DESCRIPTION
Hopefully this makes it easier to debug failures.

I also changed the test to only catch `NonFatal` throwables.