### PR TITLE
Override reverse in Order.reverse value

### DIFF
--- a/core/src/main/scala/algebra/Order.scala
+++ b/core/src/main/scala/algebra/Order.scala
@@ -56,6 +56,8 @@ trait Order[@sp A] extends Any with PartialOrder[A] { self =>
   override def reverse: Order[A] =
     new Order[A] {
       def compare(x: A, y: A): Int = self.compare(y, x)
+
+      override def reverse: Order[A] = self
     }
 
   // The following may be overridden for performance:


### PR DESCRIPTION
Override the `reverse` implementation in the result of `Order.reverse`
to simply return the original `Order` instance.