### PR TITLE
Add Order.fromOrdering method

### DIFF
--- a/core/src/main/scala/algebra/Order.scala
+++ b/core/src/main/scala/algebra/Order.scala
@@ -200,4 +200,10 @@ object Order extends OrderFunctions {
 
       def combine(x: Order[A], y: Order[A]): Order[A] = x whenEqual y
     }
+
+  def fromOrdering[A](implicit ev: Ordering[A]): Order[A] = new Order[A] {
+    def compare(x: A, y: A): Int = ev.compare(x, y)
+
+    override def toOrdering: Ordering[A] = ev
+  }
 }

--- a/laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -169,5 +169,7 @@ trait LawTestsBase extends FunSuite with Discipline {
     implicit val monoidOrderN: Monoid[Order[N]] = Order.whenEqualMonoid[N]
     laws[GroupLaws, Order[N]].check(_.monoid)
   }
+
+  laws[OrderLaws, Int]("fromOrdering").check(_.order(Order.fromOrdering[Int]))
 }
 


### PR DESCRIPTION
This provides a conversion from `scala.math.Ordering` to
`algebra.Order`.

I might be abusing the `extraTag` form of the `laws` function, I'm not
sure. If I don't provide a label then I get a duplicate test name error.