### PR TITLE
Add Eq and PartialOrder instances for List.

### DIFF
--- a/std/src/main/scala/algebra/std/list.scala
+++ b/std/src/main/scala/algebra/std/list.scala
@@ -6,12 +6,12 @@ import scala.collection.mutable
 
 package object list extends ListInstances 
 
-trait ListInstances {
+trait ListInstances extends ListInstances1 {
   implicit def listOrder[A: Order] = new ListOrder[A]
   implicit def listMonoid[A] = new ListMonoid[A]
 }
 
-trait ListInstances1 {
+trait ListInstances1 extends ListInstances2 {
   implicit def listPartialOrder[A: PartialOrder] = new ListPartialOrder[A]
 }
 

--- a/std/src/main/scala/algebra/std/list.scala
+++ b/std/src/main/scala/algebra/std/list.scala
@@ -11,6 +11,14 @@ trait ListInstances {
   implicit def listMonoid[A] = new ListMonoid[A]
 }
 
+trait ListInstances1 {
+  implicit def listPartialOrder[A: PartialOrder] = new ListPartialOrder[A]
+}
+
+trait ListInstances2 {
+  implicit def listEq[A: Eq] = new ListEq[A]
+}
+
 class ListOrder[A](implicit ev: Order[A]) extends Order[List[A]] {
   def compare(xs: List[A], ys: List[A]): Int = {
     @tailrec def loop(xs: List[A], ys: List[A]): Int =
@@ -29,18 +37,54 @@ class ListOrder[A](implicit ev: Order[A]) extends Order[List[A]] {
   }
 }
 
+class ListPartialOrder[A](implicit ev: PartialOrder[A]) extends PartialOrder[List[A]] {
+  def partialCompare(xs: List[A], ys: List[A]): Double = {
+    @tailrec def loop(xs: List[A], ys: List[A]): Double =
+      xs match {
+        case Nil =>
+          if (ys.isEmpty) 0.0 else -1.0
+        case x :: xs =>
+          ys match {
+            case Nil => 1.0
+            case y :: ys =>
+              val n = ev.partialCompare(x, y)
+              if (n != 0.0) n else loop(xs, ys)
+          }
+      }
+    loop(xs, ys)
+  }
+}
+
+class ListEq[A](implicit ev: Eq[A]) extends Eq[List[A]] {
+  def eqv(x: List[A], y: List[A]): Boolean = {
+    def loop(xs: List[A], ys: List[A]): Boolean =
+      xs match {
+        case Nil =>
+          ys.isEmpty
+        case x :: xs =>
+          ys match {
+            case y :: ys =>
+              if (ev.eqv(x, y)) loop(xs, ys) else false
+            case Nil =>
+              false
+          }
+      }
+    loop(x, y)
+  }
+}
+
 class ListMonoid[A] extends Monoid[List[A]] {
   def empty: List[A] = Nil
   def combine(x: List[A], y: List[A]): List[A] = x ::: y
 
   override def combineN(x: List[A], n: Int): List[A] = {
     val buf = mutable.ListBuffer.empty[A]
-    @tailrec def loop(i: Int): List[A] =
-      if (i <= 0) buf.toList else {
-        buf ++= x
-        loop(i - 1)
-      }
-    loop(n)
+    var i = n
+    while (i > 0) {
+      buf ++= x
+      i -= 1
+    }
+    buf.toList
   }
 
   override def combineAll(xs: TraversableOnce[List[A]]): List[A] = {


### PR DESCRIPTION
Fixes #118.

Note that if we want to support "pairwise instances" for additive/multiplicative semigroups for lists they would be really easy to do (treating uneven lengths as one/zero padded).