### PR TITLE
Add parameters to all functions that extend/are extended

### DIFF
--- a/core/src/main/scala/algebra/CommutativeGroup.scala
+++ b/core/src/main/scala/algebra/CommutativeGroup.scala
@@ -7,10 +7,11 @@ import scala.{ specialized => sp }
  */
 trait CommutativeGroup[@sp(Int, Long, Float, Double) A] extends Any with Group[A] with CommutativeMonoid[A]
 
-object CommutativeGroup extends GroupFunctions {
+object CommutativeGroup extends GroupFunctions[CommutativeGroup] {
 
   /**
    * Access an implicit `CommutativeGroup[A]`.
    */
   @inline final def apply[A](implicit ev: CommutativeGroup[A]): CommutativeGroup[A] = ev
 }
+

--- a/core/src/main/scala/algebra/CommutativeMonoid.scala
+++ b/core/src/main/scala/algebra/CommutativeMonoid.scala
@@ -9,7 +9,7 @@ import scala.{ specialized => sp }
  */
 trait CommutativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with Monoid[A] with CommutativeSemigroup[A]
 
-object CommutativeMonoid extends MonoidFunctions {
+object CommutativeMonoid extends MonoidFunctions[CommutativeMonoid] {
   /**
    * Access an implicit `CommutativeMonoid[A]`.
    */

--- a/core/src/main/scala/algebra/CommutativeSemigroup.scala
+++ b/core/src/main/scala/algebra/CommutativeSemigroup.scala
@@ -9,7 +9,7 @@ import scala.{ specialized => sp }
  */
 trait CommutativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A]
 
-object CommutativeSemigroup extends SemigroupFunctions {
+object CommutativeSemigroup extends SemigroupFunctions[CommutativeSemigroup] {
 
   /**
    * Access an implicit `CommutativeSemigroup[A]`.

--- a/core/src/main/scala/algebra/Group.scala
+++ b/core/src/main/scala/algebra/Group.scala
@@ -32,14 +32,14 @@ trait Group[@sp(Int, Long, Float, Double) A] extends Any with Monoid[A] {
     else repeatedCombineN(inverse(a), -n)
 }
 
-trait GroupFunctions extends MonoidFunctions {
-  def inverse[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: Group[A]): A =
+trait GroupFunctions[G[T] <: Group[T]] extends MonoidFunctions[Group] {
+  def inverse[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: G[A]): A =
     ev.inverse(a)
-  def remove[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Group[A]): A =
+  def remove[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: G[A]): A =
     ev.remove(x, y)
 }
 
-object Group extends GroupFunctions {
+object Group extends GroupFunctions[Group] {
 
   /**
    * Access an implicit `Group[A]`.

--- a/core/src/main/scala/algebra/Monoid.scala
+++ b/core/src/main/scala/algebra/Monoid.scala
@@ -35,15 +35,15 @@ trait Monoid[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] {
     as.foldLeft(empty)(combine)
 }
 
-trait MonoidFunctions extends SemigroupFunctions {
-  def empty[@sp(Int, Long, Float, Double) A](implicit ev: Monoid[A]): A =
+trait MonoidFunctions[M[T] <: Monoid[T]] extends SemigroupFunctions[M] {
+  def empty[@sp(Int, Long, Float, Double) A](implicit ev: M[A]): A =
     ev.empty
 
-  def combineAll[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Monoid[A]): A =
+  def combineAll[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: M[A]): A =
     ev.combineAll(as)
 }
 
-object Monoid extends MonoidFunctions {
+object Monoid extends MonoidFunctions[Monoid] {
 
   /**
    * Access an implicit `Monoid[A]`.

--- a/core/src/main/scala/algebra/Semigroup.scala
+++ b/core/src/main/scala/algebra/Semigroup.scala
@@ -41,36 +41,36 @@ trait Semigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
     as.reduceOption(combine)
 }
 
-trait SemigroupFunctions {
-  def combine[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Semigroup[A]): A =
+trait SemigroupFunctions[S[T] <: Semigroup[T]] {
+  def combine[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: S[A]): A =
     ev.combine(x, y)
 
-  def maybeCombine[@sp(Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: Semigroup[A]): A =
+  def maybeCombine[@sp(Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: S[A]): A =
     ox match {
       case Some(x) => ev.combine(x, y)
       case None => y
     }
 
-  def maybeCombine[@sp(Int, Long, Float, Double) A](x: A, oy: Option[A])(implicit ev: Semigroup[A]): A =
+  def maybeCombine[@sp(Int, Long, Float, Double) A](x: A, oy: Option[A])(implicit ev: S[A]): A =
     oy match {
       case Some(y) => ev.combine(x, y)
       case None => x
     }
 
-  def isCommutative[A](implicit ev: Semigroup[A]): Boolean =
+  def isCommutative[A](implicit ev: S[A]): Boolean =
     ev.isInstanceOf[CommutativeSemigroup[_]]
 
-  def isIdempotent[A](implicit ev: Semigroup[A]): Boolean =
+  def isIdempotent[A](implicit ev: S[A]): Boolean =
     ev.isInstanceOf[Band[_]]
 
-  def combineN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: Semigroup[A]): A =
+  def combineN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: S[A]): A =
     ev.combineN(a, n)
 
-  def combineAllOption[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Semigroup[A]): Option[A] =
+  def combineAllOption[A](as: TraversableOnce[A])(implicit ev: S[A]): Option[A] =
     ev.combineAllOption(as)
 }
 
-object Semigroup extends SemigroupFunctions {
+object Semigroup extends SemigroupFunctions[Semigroup] {
 
   /**
    * Access an implicit `Semigroup[A]`.

--- a/lattice/src/main/scala/algebra/lattice/Bool.scala
+++ b/lattice/src/main/scala/algebra/lattice/Bool.scala
@@ -80,20 +80,7 @@ class BoolFromBoolRing[A](orig: BoolRing[A]) extends GenBoolFromBoolRng(orig) wi
   override def asBoolRing: BoolRing[A] = orig
 }
 
-trait BoolFunctions {
-  def dual[@sp(Int, Long) A](implicit ev: Bool[A]): Bool[A] =
-    ev.dual
-  def xor[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
-    ev.xor(x, y)
-  def nand[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
-    ev.nand(x, y)
-  def nor[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
-    ev.nor(x, y)
-  def nxor[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
-    ev.nxor(x, y)
-}
-
-object Bool extends HeytingFunctions with BoolFunctions {
+object Bool extends HeytingFunctions[Bool] with GenBoolFunctions[Bool] {
 
   /**
    * Access an implicit `Bool[A]`.

--- a/lattice/src/main/scala/algebra/lattice/BoundedDistributiveLattice.scala
+++ b/lattice/src/main/scala/algebra/lattice/BoundedDistributiveLattice.scala
@@ -29,7 +29,9 @@ trait BoundedDistributiveLattice[@sp(Int, Long, Float, Double) A] extends Any wi
   }
 }
 
-object BoundedDistributiveLattice extends LatticeFunctions with BoundedLatticeFunctions {
+object BoundedDistributiveLattice extends
+  BoundedMeetSemilatticeFunctions[BoundedDistributiveLattice] with
+  BoundedJoinSemilatticeFunctions[BoundedDistributiveLattice] {
 
   /**
    * Access an implicit `BoundedDistributiveLattice[A]`.
@@ -37,10 +39,11 @@ object BoundedDistributiveLattice extends LatticeFunctions with BoundedLatticeFu
   @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: BoundedDistributiveLattice[A]): BoundedDistributiveLattice[A] = ev
 
   def minMax[@sp(Int, Long, Float, Double)A](min: A, max: A)(implicit ord: Order[A]): BoundedDistributiveLattice[A] =
-    new BoundedDistributiveLattice[A] {
-      def zero = min
-      def one = max
-      def join(a: A, b: A) = ord.max(a, b)
-      def meet(a: A, b: A) = ord.min(a, b)
-    }
+    new MinMaxBoundedDistributiveLattice(min, max)
+}
+
+class MinMaxBoundedDistributiveLattice[A](min: A, max: A)(implicit o: Order[A]) extends MinMaxLattice[A]
+  with BoundedDistributiveLattice[A] {
+  def zero = min
+  def one = max
 }

--- a/lattice/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
+++ b/lattice/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
@@ -14,7 +14,12 @@ trait BoundedJoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with J
     }
 }
 
-object BoundedJoinSemilattice {
+trait BoundedJoinSemilatticeFunctions[B[A] <: BoundedJoinSemilattice[A]] extends JoinSemilatticeFunctions[B] {
+  def zero[@sp(Int, Long, Float, Double) A](implicit ev: B[A]): A = ev.zero
+}
+
+object BoundedJoinSemilattice extends JoinSemilatticeFunctions[BoundedJoinSemilattice]
+  with BoundedJoinSemilatticeFunctions[BoundedJoinSemilattice] {
 
   /**
    * Access an implicit `BoundedJoinSemilattice[A]`.

--- a/lattice/src/main/scala/algebra/lattice/BoundedLattice.scala
+++ b/lattice/src/main/scala/algebra/lattice/BoundedLattice.scala
@@ -26,15 +26,9 @@ trait BoundedLattice[@sp(Int, Long, Float, Double) A] extends Any with Lattice[A
   }
 }
 
-trait BoundedLatticeFunctions {
-  def zero[@sp(Int, Long, Float, Double) A](implicit ev: BoundedJoinSemilattice[A]): A =
-    ev.zero
-
-  def one[@sp(Int, Long, Float, Double) A](implicit ev: BoundedMeetSemilattice[A]): A =
-    ev.one
-}
-
-object BoundedLattice extends LatticeFunctions with BoundedLatticeFunctions {
+object BoundedLattice extends
+  BoundedMeetSemilatticeFunctions[BoundedLattice] with
+  BoundedJoinSemilatticeFunctions[BoundedLattice] {
 
   /**
    * Access an implicit `BoundedLattice[A]`.

--- a/lattice/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
+++ b/lattice/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
@@ -14,7 +14,12 @@ trait BoundedMeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with M
     }
 }
 
-object BoundedMeetSemilattice {
+trait BoundedMeetSemilatticeFunctions[B[A] <: BoundedMeetSemilattice[A]] extends MeetSemilatticeFunctions[B] {
+  def one[@sp(Int, Long, Float, Double) A](implicit ev: B[A]): A =
+    ev.one
+}
+
+object BoundedMeetSemilattice extends BoundedMeetSemilatticeFunctions[BoundedMeetSemilattice] {
 
   /**
    * Access an implicit `BoundedMeetSemilattice[A]`.

--- a/lattice/src/main/scala/algebra/lattice/DistributiveLattice.scala
+++ b/lattice/src/main/scala/algebra/lattice/DistributiveLattice.scala
@@ -11,7 +11,7 @@ import scala.{specialized => sp}
  */
 trait DistributiveLattice[@sp(Int, Long, Float, Double) A] extends Any with Lattice[A]
 
-object DistributiveLattice extends LatticeFunctions {
+object DistributiveLattice extends JoinSemilatticeFunctions[DistributiveLattice] with MeetSemilatticeFunctions[DistributiveLattice] {
 
   /**
    * Access an implicit `Lattice[A]`.

--- a/lattice/src/main/scala/algebra/lattice/GenBool.scala
+++ b/lattice/src/main/scala/algebra/lattice/GenBool.scala
@@ -63,14 +63,13 @@ private[lattice] class BoolRngFromGenBool[@sp(Int, Long) A](orig: GenBool[A]) ex
   def times(x: A, y: A): A = orig.and(x, y)
 }
 
-trait GenBoolFunctions {
-  def zero[@sp(Int, Long) A](implicit ev: GenBool[A]): A = ev.zero
-  def and[@sp(Int, Long) A](x: A, y: A)(implicit ev: GenBool[A]): A = ev.and(x, y)
-  def or[@sp(Int, Long) A](x: A, y: A)(implicit ev: GenBool[A]): A = ev.or(x, y)
-  def without[@sp(Int, Long) A](x: A, y: A)(implicit ev: GenBool[A]): A = ev.without(x, y)
-  def xor[@sp(Int, Long) A](x: A, y: A)(implicit ev: GenBool[A]): A = ev.xor(x, y)
+trait GenBoolFunctions[G[A] <: GenBool[A]] extends BoundedJoinSemilatticeFunctions[G] with MeetSemilatticeFunctions[G] {
+  def and[@sp(Int, Long) A](x: A, y: A)(implicit ev: G[A]): A = ev.and(x, y)
+  def or[@sp(Int, Long) A](x: A, y: A)(implicit ev: G[A]): A = ev.or(x, y)
+  def without[@sp(Int, Long) A](x: A, y: A)(implicit ev: G[A]): A = ev.without(x, y)
+  def xor[@sp(Int, Long) A](x: A, y: A)(implicit ev: G[A]): A = ev.xor(x, y)
 }
 
-object GenBool extends BoolFunctions {
+object GenBool extends GenBoolFunctions[GenBool] {
   @inline final def apply[@sp(Int, Long) A](implicit ev: GenBool[A]): GenBool[A] = ev
 }

--- a/lattice/src/main/scala/algebra/lattice/Heyting.scala
+++ b/lattice/src/main/scala/algebra/lattice/Heyting.scala
@@ -49,23 +49,34 @@ trait Heyting[@sp(Int, Long) A] extends Any with BoundedDistributiveLattice[A] {
   def nxor(a: A, b: A): A = complement(xor(a, b))
 }
 
-trait HeytingFunctions {
-  def zero[@sp(Int, Long) A](implicit ev: Bool[A]): A = ev.zero
-  def one[@sp(Int, Long) A](implicit ev: Bool[A]): A = ev.one
+trait HeytingGenBoolOverlap[H[A] <: Heyting[A]] {
+  def and[@sp(Int, Long) A](x: A, y: A)(implicit ev: H[A]): A =
+    ev.and(x, y)
+  def or[@sp(Int, Long) A](x: A, y: A)(implicit ev: H[A]): A =
+    ev.or(x, y)
+  def xor[@sp(Int, Long) A](x: A, y: A)(implicit ev: H[A]): A =
+    ev.xor(x, y)
+}
 
-  def complement[@sp(Int, Long) A](x: A)(implicit ev: Bool[A]): A =
+trait HeytingFunctions[H[A] <: Heyting[A]] extends
+  BoundedMeetSemilatticeFunctions[H] with
+  BoundedJoinSemilatticeFunctions[H] {
+
+  def complement[@sp(Int, Long) A](x: A)(implicit ev: H[A]): A =
     ev.complement(x)
 
-  def and[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
-    ev.and(x, y)
-  def or[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
-    ev.or(x, y)
-  def imp[@sp(Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def imp[@sp(Int, Long) A](x: A, y: A)(implicit ev: H[A]): A =
     ev.imp(x, y)
+  def nor[@sp(Int, Long) A](x: A, y: A)(implicit ev: H[A]): A =
+    ev.nor(x, y)
+  def nxor[@sp(Int, Long) A](x: A, y: A)(implicit ev: H[A]): A =
+    ev.nxor(x, y)
+  def nand[@sp(Int, Long) A](x: A, y: A)(implicit ev: H[A]): A =
+    ev.nand(x, y)
 }
 
 
-object Heyting extends HeytingFunctions {
+object Heyting extends HeytingFunctions[Heyting] with HeytingGenBoolOverlap[Heyting] {
 
   /**
    * Access an implicit `Heyting[A]`.

--- a/lattice/src/main/scala/algebra/lattice/JoinSemilattice.scala
+++ b/lattice/src/main/scala/algebra/lattice/JoinSemilattice.scala
@@ -20,7 +20,12 @@ trait JoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializ
     joinSemilattice.asJoinPartialOrder
 }
 
-object JoinSemilattice {
+trait JoinSemilatticeFunctions[J[A] <: JoinSemilattice[A]] {
+  def join[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: J[A]): A =
+    ev.join(x, y)
+}
+
+object JoinSemilattice extends JoinSemilatticeFunctions[JoinSemilattice] {
 
   /**
    * Access an implicit `JoinSemilattice[A]`.

--- a/lattice/src/main/scala/algebra/lattice/Lattice.scala
+++ b/lattice/src/main/scala/algebra/lattice/Lattice.scala
@@ -28,16 +28,7 @@ trait Lattice[@sp(Int, Long, Float, Double) A] extends Any with JoinSemilattice[
   }
 }
 
-trait LatticeFunctions {
-  def join[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: JoinSemilattice[A]): A =
-    ev.join(x, y)
-
-  def meet[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MeetSemilattice[A]): A =
-    ev.meet(x, y)
-}
-
-object Lattice extends LatticeFunctions {
-
+object Lattice extends JoinSemilatticeFunctions[Lattice] with MeetSemilatticeFunctions[Lattice] {
   /**
    * Access an implicit `Lattice[A]`.
    */

--- a/lattice/src/main/scala/algebra/lattice/MeetSemilattice.scala
+++ b/lattice/src/main/scala/algebra/lattice/MeetSemilattice.scala
@@ -20,7 +20,12 @@ trait MeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializ
     meetSemilattice.asMeetPartialOrder
 }
 
-object MeetSemilattice {
+trait MeetSemilatticeFunctions[M[A] <: MeetSemilattice[A]] {
+  def meet[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: M[A]): A =
+    ev.meet(x, y)
+}
+
+object MeetSemilattice extends MeetSemilatticeFunctions[MeetSemilattice] {
 
   /**
    * Access an implicit `MeetSemilattice[A]`.

--- a/ring/src/main/scala/algebra/ring/Additive.scala
+++ b/ring/src/main/scala/algebra/ring/Additive.scala
@@ -98,40 +98,40 @@ trait AdditiveCommutativeGroup[@sp(Int, Long, Float, Double) A] extends Any with
   }
 }
 
-trait AdditiveSemigroupFunctions {
+trait AdditiveSemigroupFunctions[S[T] <: AdditiveSemigroup[T]] {
 
-  def isCommutative[A](implicit ev: AdditiveSemigroup[A]): Boolean =
+  def isAdditiveCommutative[A](implicit ev: S[A]): Boolean =
     ev.isInstanceOf[AdditiveCommutativeSemigroup[_]]
 
-  def plus[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveSemigroup[A]): A =
+  def plus[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: S[A]): A =
     ev.plus(x, y)
 
-  def sumN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: AdditiveSemigroup[A]): A =
+  def sumN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: S[A]): A =
     ev.sumN(a, n)
 
-  def trySum[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveSemigroup[A]): Option[A] =
+  def trySum[A](as: TraversableOnce[A])(implicit ev: S[A]): Option[A] =
     ev.trySum(as)
 }
 
-trait AdditiveMonoidFunctions extends AdditiveSemigroupFunctions {
-  def zero[@sp(Int, Long, Float, Double) A](implicit ev: AdditiveMonoid[A]): A =
+trait AdditiveMonoidFunctions[M[T] <: AdditiveMonoid[T]]  extends AdditiveSemigroupFunctions[M] {
+  def zero[@sp(Int, Long, Float, Double) A](implicit ev: M[A]): A =
     ev.zero
 
-  def isZero[@sp(Int, Long, Float, Double) A](a: A)(implicit ev0: AdditiveMonoid[A], ev1: Eq[A]): Boolean =
+  def isZero[@sp(Int, Long, Float, Double) A](a: A)(implicit ev0: M[A], ev1: Eq[A]): Boolean =
     ev0.isZero(a)
 
-  def sum[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveMonoid[A]): A =
+  def sum[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: M[A]): A =
     ev.sum(as)
 }
 
-trait AdditiveGroupFunctions extends AdditiveMonoidFunctions {
-  def negate[@sp(Int, Long, Float, Double) A](x: A)(implicit ev: AdditiveGroup[A]): A =
+trait AdditiveGroupFunctions[G[T] <: AdditiveGroup[T]]  extends AdditiveMonoidFunctions[G] {
+  def negate[@sp(Int, Long, Float, Double) A](x: A)(implicit ev: G[A]): A =
     ev.negate(x)
-  def minus[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveGroup[A]): A =
+  def minus[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: G[A]): A =
     ev.minus(x, y)
 }
 
-object AdditiveSemigroup extends AdditiveSemigroupFunctions {
+object AdditiveSemigroup extends AdditiveSemigroupFunctions[AdditiveSemigroup] {
   @inline final def apply[A](implicit ev: AdditiveSemigroup[A]): AdditiveSemigroup[A] = ev
   /**
    * This method converts an additive instance into a generic
@@ -144,7 +144,7 @@ object AdditiveSemigroup extends AdditiveSemigroupFunctions {
     ev.additive
 }
 
-object AdditiveCommutativeSemigroup extends AdditiveSemigroupFunctions {
+object AdditiveCommutativeSemigroup extends AdditiveSemigroupFunctions[AdditiveCommutativeSemigroup] {
   @inline final def apply[A](implicit ev: AdditiveCommutativeSemigroup[A]): AdditiveCommutativeSemigroup[A] = ev
   /**
    * This method converts an additive instance into a generic
@@ -157,7 +157,7 @@ object AdditiveCommutativeSemigroup extends AdditiveSemigroupFunctions {
     ev.additive
 }
 
-object AdditiveMonoid extends AdditiveMonoidFunctions {
+object AdditiveMonoid extends AdditiveMonoidFunctions[AdditiveMonoid] {
   @inline final def apply[A](implicit ev: AdditiveMonoid[A]): AdditiveMonoid[A] = ev
   /**
    * This method converts an additive instance into a generic
@@ -170,7 +170,7 @@ object AdditiveMonoid extends AdditiveMonoidFunctions {
     ev.additive
 }
 
-object AdditiveCommutativeMonoid extends AdditiveMonoidFunctions {
+object AdditiveCommutativeMonoid extends AdditiveMonoidFunctions[AdditiveCommutativeMonoid] {
   @inline final def apply[A](implicit ev: AdditiveCommutativeMonoid[A]): AdditiveCommutativeMonoid[A] = ev
   /**
    * This method converts an additive instance into a generic
@@ -183,7 +183,7 @@ object AdditiveCommutativeMonoid extends AdditiveMonoidFunctions {
     ev.additive
 }
 
-object AdditiveGroup extends AdditiveGroupFunctions {
+object AdditiveGroup extends AdditiveGroupFunctions[AdditiveGroup] {
   @inline final def apply[A](implicit ev: AdditiveGroup[A]): AdditiveGroup[A] = ev
   /**
    * This method converts an additive instance into a generic
@@ -196,7 +196,7 @@ object AdditiveGroup extends AdditiveGroupFunctions {
     ev.additive
 }
 
-object AdditiveCommutativeGroup extends AdditiveGroupFunctions {
+object AdditiveCommutativeGroup extends AdditiveGroupFunctions[AdditiveCommutativeGroup] {
   @inline final def apply[A](implicit ev: AdditiveCommutativeGroup[A]): AdditiveCommutativeGroup[A] = ev
   /**
    * This method converts an additive instance into a generic

--- a/ring/src/main/scala/algebra/ring/BoolRng.scala
+++ b/ring/src/main/scala/algebra/ring/BoolRng.scala
@@ -13,6 +13,6 @@ trait BoolRng[A] extends Any with Rng[A] { self =>
   override final def negate(x: A): A = x
 }
 
-object BoolRng extends AdditiveGroupFunctions with MultiplicativeSemigroupFunctions {
+object BoolRng extends AdditiveGroupFunctions[BoolRng] with MultiplicativeSemigroupFunctions[BoolRng] {
   @inline final def apply[A](implicit r: BoolRng[A]): BoolRng[A] = r
 }

--- a/ring/src/main/scala/algebra/ring/CommutativeRig.scala
+++ b/ring/src/main/scala/algebra/ring/CommutativeRig.scala
@@ -8,6 +8,6 @@ import scala.{specialized => sp}
  */
 trait CommutativeRig[@sp(Int, Long, Float, Double) A] extends Any with Rig[A] with MultiplicativeCommutativeMonoid[A]
 
-object CommutativeRig extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
+object CommutativeRig extends AdditiveMonoidFunctions[CommutativeRig] with MultiplicativeMonoidFunctions[CommutativeRig] {
   @inline final def apply[A](implicit r: CommutativeRig[A]): CommutativeRig[A] = r
 }

--- a/ring/src/main/scala/algebra/ring/Field.scala
+++ b/ring/src/main/scala/algebra/ring/Field.scala
@@ -41,7 +41,7 @@ trait Field[@sp(Int, Long, Float, Double) A] extends Any with EuclideanRing[A] w
     }
 }
 
-trait FieldFunctions[F[T] <: Field[T]] extends EuclideanRingFunctions[F] with MultiplicativeGroupFunctions {
+trait FieldFunctions[F[T] <: Field[T]] extends EuclideanRingFunctions[F] with MultiplicativeGroupFunctions[F] {
   def fromDouble[@sp(Int, Long, Float, Double) A](n: Double)(implicit ev: F[A]): A =
     ev.fromDouble(n)
 }

--- a/ring/src/main/scala/algebra/ring/Multiplicative.scala
+++ b/ring/src/main/scala/algebra/ring/Multiplicative.scala
@@ -99,38 +99,38 @@ trait MultiplicativeCommutativeGroup[@sp(Int, Long, Float, Double) A] extends An
   }
 }
 
-trait MultiplicativeSemigroupFunctions {
-  def isCommutative[A](implicit ev: MultiplicativeSemigroup[A]): Boolean =
+trait MultiplicativeSemigroupFunctions[S[T] <: MultiplicativeSemigroup[T]] {
+  def isMultiplicativeCommutative[A](implicit ev: S[A]): Boolean =
     ev.isInstanceOf[MultiplicativeCommutativeSemigroup[A]]
 
-  def times[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeSemigroup[A]): A =
+  def times[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: S[A]): A =
     ev.times(x, y)
-  def pow[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: MultiplicativeSemigroup[A]): A =
+  def pow[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: S[A]): A =
     ev.pow(a, n)
 
-  def tryProduct[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeSemigroup[A]): Option[A] =
+  def tryProduct[A](as: TraversableOnce[A])(implicit ev: S[A]): Option[A] =
     ev.tryProduct(as)
 }
 
-trait MultiplicativeMonoidFunctions extends MultiplicativeSemigroupFunctions {
-  def one[@sp(Int, Long, Float, Double) A](implicit ev: MultiplicativeMonoid[A]): A =
+trait MultiplicativeMonoidFunctions[M[T] <: MultiplicativeMonoid[T]] extends MultiplicativeSemigroupFunctions[M] {
+  def one[@sp(Int, Long, Float, Double) A](implicit ev: M[A]): A =
     ev.one
 
-  def isOne[@sp(Int, Long, Float, Double) A](a: A)(implicit ev0: MultiplicativeMonoid[A], ev1: Eq[A]): Boolean =
+  def isOne[@sp(Int, Long, Float, Double) A](a: A)(implicit ev0: M[A], ev1: Eq[A]): Boolean =
     ev0.isOne(a)
 
-  def product[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeMonoid[A]): A =
+  def product[@sp(Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: M[A]): A =
     ev.product(as)
 }
 
-trait MultiplicativeGroupFunctions extends MultiplicativeMonoidFunctions {
-  def reciprocal[@sp(Int, Long, Float, Double) A](x: A)(implicit ev: MultiplicativeGroup[A]): A =
+trait MultiplicativeGroupFunctions[G[T] <: MultiplicativeGroup[T]] extends MultiplicativeMonoidFunctions[G] {
+  def reciprocal[@sp(Int, Long, Float, Double) A](x: A)(implicit ev: G[A]): A =
     ev.reciprocal(x)
-  def div[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeGroup[A]): A =
+  def div[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: G[A]): A =
     ev.div(x, y)
 }
 
-object MultiplicativeSemigroup extends MultiplicativeSemigroupFunctions {
+object MultiplicativeSemigroup extends MultiplicativeSemigroupFunctions[MultiplicativeSemigroup] {
   @inline final def apply[A](implicit ev: MultiplicativeSemigroup[A]): MultiplicativeSemigroup[A] = ev
   /**
    * This method converts a multiplicative instance into a generic
@@ -143,7 +143,7 @@ object MultiplicativeSemigroup extends MultiplicativeSemigroupFunctions {
     ev.multiplicative
 }
 
-object MultiplicativeCommutativeSemigroup extends MultiplicativeSemigroupFunctions {
+object MultiplicativeCommutativeSemigroup extends MultiplicativeSemigroupFunctions[MultiplicativeCommutativeSemigroup] {
   @inline final def apply[A](implicit ev: MultiplicativeCommutativeSemigroup[A]): MultiplicativeCommutativeSemigroup[A] = ev
   /**
    * This method converts a multiplicative instance into a generic
@@ -156,7 +156,7 @@ object MultiplicativeCommutativeSemigroup extends MultiplicativeSemigroupFunctio
     ev.multiplicative
 }
 
-object MultiplicativeMonoid extends MultiplicativeMonoidFunctions {
+object MultiplicativeMonoid extends MultiplicativeMonoidFunctions[MultiplicativeMonoid] {
   @inline final def apply[A](implicit ev: MultiplicativeMonoid[A]): MultiplicativeMonoid[A] = ev
   /**
    * This method converts a multiplicative instance into a generic
@@ -169,7 +169,7 @@ object MultiplicativeMonoid extends MultiplicativeMonoidFunctions {
     ev.multiplicative
 }
 
-object MultiplicativeCommutativeMonoid extends MultiplicativeMonoidFunctions {
+object MultiplicativeCommutativeMonoid extends MultiplicativeMonoidFunctions[MultiplicativeCommutativeMonoid] {
   @inline final def apply[A](implicit ev: MultiplicativeCommutativeMonoid[A]): MultiplicativeCommutativeMonoid[A] = ev
   /**
    * This method converts a multiplicative instance into a generic
@@ -182,7 +182,7 @@ object MultiplicativeCommutativeMonoid extends MultiplicativeMonoidFunctions {
     ev.multiplicative
 }
 
-object MultiplicativeGroup extends MultiplicativeGroupFunctions {
+object MultiplicativeGroup extends MultiplicativeGroupFunctions[MultiplicativeGroup] {
   @inline final def apply[A](implicit ev: MultiplicativeGroup[A]): MultiplicativeGroup[A] = ev
   /**
    * This method converts a multiplicative instance into a generic
@@ -195,7 +195,7 @@ object MultiplicativeGroup extends MultiplicativeGroupFunctions {
     ev.multiplicative
 }
 
-object MultiplicativeCommutativeGroup extends MultiplicativeGroupFunctions {
+object MultiplicativeCommutativeGroup extends MultiplicativeGroupFunctions[MultiplicativeCommutativeGroup] {
   @inline final def apply[A](implicit ev: MultiplicativeCommutativeGroup[A]): MultiplicativeCommutativeGroup[A] = ev
   /**
    * This method converts a multiplicative instance into a generic

--- a/ring/src/main/scala/algebra/ring/Rig.scala
+++ b/ring/src/main/scala/algebra/ring/Rig.scala
@@ -6,10 +6,10 @@ import scala.{specialized => sp}
 
 /**
  * Rig consists of:
- * 
+ *
  *  - a commutative monoid for addition (+)
  *  - a monoid for multiplication (*)
- * 
+ *
  * Alternately, a Rig can be thought of as a ring without
  * multiplicative or additive inverses (or as a semiring with a
  * multiplicative identity).
@@ -18,6 +18,6 @@ import scala.{specialized => sp}
  */
 trait Rig[@sp(Int, Long, Float, Double) A] extends Any with Semiring[A] with MultiplicativeMonoid[A]
 
-object Rig extends AdditiveMonoidFunctions with MultiplicativeMonoidFunctions {
+object Rig extends AdditiveMonoidFunctions[Rig] with MultiplicativeMonoidFunctions[Rig] {
   @inline final def apply[A](implicit ev: Rig[A]): Rig[A] = ev
 }

--- a/ring/src/main/scala/algebra/ring/Ring.scala
+++ b/ring/src/main/scala/algebra/ring/Ring.scala
@@ -5,12 +5,12 @@ import scala.{specialized => sp}
 
 /**
  * Ring consists of:
- * 
+ *
  *  - a commutative group for addition (+)
  *  - a monoid for multiplication (*)
- * 
+ *
  * Additionally, multiplication must distribute over addition.
- * 
+ *
  * Ring implements some methods (for example fromInt) in terms of
  * other more fundamental methods (zero, one and plus). Where
  * possible, these methods should be overridden by more efficient
@@ -20,19 +20,19 @@ trait Ring[@sp(Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] 
 
   /**
    * Convert the given integer to an instance of A.
-   * 
+   *
    * Defined to be equivalent to `sumN(one, n)`.
-   * 
+   *
    * That is, `n` repeated summations of this ring's `one`, or `-n`
    * summations of `-one` if `n` is negative.
-   * 
+   *
    * Most type class instances should consider overriding this method
    * for performance reasons.
    */
   def fromInt(n: Int): A = sumN(one, n)
 }
 
-trait RingFunctions[R[T] <: Ring[T]] extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
+trait RingFunctions[R[T] <: Ring[T]] extends AdditiveGroupFunctions[R] with MultiplicativeMonoidFunctions[R] {
   def fromInt[@sp(Int, Long, Float, Double) A](n: Int)(implicit ev: R[A]): A =
     ev.fromInt(n)
 }

--- a/ring/src/main/scala/algebra/ring/Rng.scala
+++ b/ring/src/main/scala/algebra/ring/Rng.scala
@@ -6,18 +6,18 @@ import scala.{specialized => sp}
 
 /**
  * Rng (pronounced "Rung") consists of:
- * 
+ *
  *  - a commutative group for addition (+)
  *  - a semigroup for multiplication (*)
  *
  * Alternately, a Rng can be thought of as a ring without a
  * multiplicative identity (or as a semiring with an additive
  * inverse).
- * 
+ *
  * Mnemonic: "Rng is a Ring without multiplicative 'I'dentity."
  */
 trait Rng[@sp(Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveCommutativeGroup[A]
 
-object Rng extends AdditiveGroupFunctions with MultiplicativeSemigroupFunctions {
+object Rng extends AdditiveGroupFunctions[Rng] with MultiplicativeSemigroupFunctions[Rng] {
   @inline final def apply[A](implicit ev: Rng[A]): Rng[A] = ev
 }

--- a/ring/src/main/scala/algebra/ring/Semiring.scala
+++ b/ring/src/main/scala/algebra/ring/Semiring.scala
@@ -6,10 +6,10 @@ import scala.{specialized => sp}
 
 /**
  * Semiring consists of:
- * 
+ *
  *  - a commutative monoid for addition (+)
  *  - a semigroup for multiplication (*)
- * 
+ *
  * Alternately, a Semiring can be thought of as a ring without a
  * multiplicative identity or an additive inverse.
  *
@@ -19,6 +19,6 @@ import scala.{specialized => sp}
  */
 trait Semiring[@sp(Int, Long, Float, Double) A] extends Any with AdditiveCommutativeMonoid[A] with MultiplicativeSemigroup[A]
 
-object Semiring extends AdditiveMonoidFunctions with MultiplicativeSemigroupFunctions {
+object Semiring extends AdditiveMonoidFunctions[Semiring] with MultiplicativeSemigroupFunctions[Semiring] {
   @inline final def apply[A](implicit ev: Semiring[A]): Semiring[A] = ev
 }


### PR DESCRIPTION
fixes #110 

This uncovered one bug: `CommutativeRig` had `AdditiveGroupFunctions` but that would never have worked for any `Rig` because it is not a group.

Also on a personal note: I prepared and submitted this PR over the state of Colorado on a flight to New Jersey.