### PR TITLE
Use diff instead of -- for set difference

### DIFF
--- a/std/src/main/scala/algebra/std/set.scala
+++ b/std/src/main/scala/algebra/std/set.scala
@@ -17,7 +17,7 @@ class SetLattice[A] extends GenBool[Set[A]] {
   def zero: Set[A] = Set.empty[A]
   def or(lhs: Set[A], rhs: Set[A]): Set[A] = lhs.union(rhs)
   def and(lhs: Set[A], rhs: Set[A]): Set[A] = lhs.intersect(rhs)
-  def without(lhs: Set[A], rhs: Set[A]): Set[A] = lhs -- rhs
+  def without(lhs: Set[A], rhs: Set[A]): Set[A] = lhs.diff(rhs)
 }
 
 class SetPartialOrder[A] extends PartialOrder[Set[A]] {
@@ -38,6 +38,6 @@ class SetSemiring[A] extends Semiring[Set[A]] {
 
 class SetBoolRng[A] extends BoolRng[Set[A]] {
   def zero: Set[A] = Set.empty
-  def plus(x: Set[A], y: Set[A]): Set[A] = (x--y) | (y--x)
+  def plus(x: Set[A], y: Set[A]): Set[A] = (x diff y) | (y diff x)
   def times(x: Set[A], y: Set[A]): Set[A] = x & y
 }


### PR DESCRIPTION
At least in case of scala.collection.immutable.HashSet, diff is a tree/tree
operation, whereas -- removes all elements of rhs from lhs one by one. So
diff is much more efficient.

I did this change (tree/tree operations) to s.c.i.HashSet for 2.11. I also think that it would be a good idea to have xor defined in s.c.i.Set for 2.12.

https://github.com/scala/scala/blob/v2.11.7/src/library/scala/collection/immutable/HashSet.scala#L1