### PR TITLE
Moved Rat into algebra.laws test scope

### DIFF
--- a/laws/jvm/src/test/scala/algebra/laws/LawTestsJvm.scala
+++ b/laws/jvm/src/test/scala/algebra/laws/LawTestsJvm.scala
@@ -2,8 +2,6 @@ package algebra
 package laws
 
 import algebra.macros._
-import algebra.std.Rat
-import CheckSupport._
 
 class LawTests extends LawTestsBase {
 

--- a/laws/shared/src/main/scala/algebra/laws/CheckSupport.scala
+++ b/laws/shared/src/main/scala/algebra/laws/CheckSupport.scala
@@ -1,10 +1,5 @@
 package algebra.laws
 
-import algebra.std.Rat
-
-import org.scalacheck._
-import Arbitrary.arbitrary
-
 /**
  * This object contains Arbitrary instances for types defined in
  * algebra.std, as well as anything else we'd like to import to assist
@@ -14,8 +9,4 @@ import Arbitrary.arbitrary
  * Arbitrary instances in companions.)
  */
 object CheckSupport {
-  implicit val ratArbitrary =
-    Arbitrary(for {
-      (n, d) <- arbitrary[(BigInt, BigInt)] if d != 0
-    } yield Rat(n, d))
 }

--- a/laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -5,7 +5,6 @@ import algebra.lattice._
 import algebra.ring._
 import algebra.macros._
 import algebra.std.all._
-import algebra.std.Rat
 
 import org.typelevel.discipline.{Laws, Predicate}
 import org.typelevel.discipline.scalatest.Discipline

--- a/laws/shared/src/test/scala/algebra/laws/Rat.scala
+++ b/laws/shared/src/test/scala/algebra/laws/Rat.scala
@@ -1,8 +1,10 @@
 package algebra
-package std
+package laws
 
 import algebra.lattice.DistributiveLattice
 import algebra.ring._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
 
 class Rat(val num: BigInt, val den: BigInt) extends Serializable { lhs =>
 
@@ -96,6 +98,11 @@ object Rat {
 
   val RatMinMaxLattice: DistributiveLattice[Rat] =
     DistributiveLattice.minMax[Rat](ratAlgebra)
+
+  implicit val ratArbitrary =
+    Arbitrary(for {
+      (n, d) <- arbitrary[(BigInt, BigInt)] if d != 0
+    } yield Rat(n, d))
 }
 
 class RatAlgebra extends Field[Rat] with Order[Rat] with Serializable {


### PR DESCRIPTION
Also moved Rat arbitrary directly into Rat companion object. CheckSupport
is now empty. Remove?

Implements #135 