### PR TITLE
use dynamic variable to control serialization tests

### DIFF
--- a/laws/jvm/src/main/scala/algebra/laws/Platform.scala
+++ b/laws/jvm/src/main/scala/algebra/laws/Platform.scala
@@ -7,28 +7,33 @@ import Prop.{False, Proof, Result}
 import scala.util.control.NonFatal
 
 private[laws] object Platform {
-
-  // Scala-js does not implement the Serializable interface, so the real test is for JVM only.
+  // Scala-js does not implement the Serializable interface, so the
+  // real test is for JVM only.
   @inline
-  def serializable[M](m: M): (String, Prop) = 
-    "serializable" -> Prop { _ =>
-      import java.io._
-      val baos = new ByteArrayOutputStream()
-      val oos = new ObjectOutputStream(baos)
-      var ois: ObjectInputStream = null
-      try {
-        oos.writeObject(m)
-        oos.close()
-        val bais = new ByteArrayInputStream(baos.toByteArray())
-        ois = new ObjectInputStream(bais)
-        val m2 = ois.readObject() // just ensure we can read it back
-        ois.close()
-        Result(status = Proof)
-      } catch { case NonFatal(t) =>
-        Result(status = Exception(t))
-      } finally {
-        oos.close()
-        if (ois != null) ois.close()
-      }
-    }
+  def serializable[M](m: M): (String, Prop) =
+    "serializable" -> (IsSerializable() match {
+      case false =>
+        Prop(_ => Result(status = Proof))
+      case true =>
+        Prop { _ =>
+          import java.io._
+          val baos = new ByteArrayOutputStream()
+          val oos = new ObjectOutputStream(baos)
+          var ois: ObjectInputStream = null
+          try {
+            oos.writeObject(m)
+            oos.close()
+            val bais = new ByteArrayInputStream(baos.toByteArray())
+            ois = new ObjectInputStream(bais)
+            val m2 = ois.readObject() // just ensure we can read it back
+            ois.close()
+            Result(status = Proof)
+          } catch { case NonFatal(t) =>
+              Result(status = Exception(t))
+          } finally {
+            oos.close()
+            if (ois != null) ois.close()
+          }
+        }
+    })
 }

--- a/laws/shared/src/main/scala/algebra/laws/IsSerializable.scala
+++ b/laws/shared/src/main/scala/algebra/laws/IsSerializable.scala
@@ -1,0 +1,12 @@
+package algebra.laws
+
+import scala.util.DynamicVariable
+
+/**
+  * Object with a dynamic variable that allows users to skip the
+  * serialization tests for certain instances.
+  */
+object IsSerializable {
+  val runTests = new DynamicVariable[Boolean](true)
+  def apply(): Boolean = runTests.value
+}

--- a/laws/shared/src/main/scala/algebra/laws/IsSerializable.scala
+++ b/laws/shared/src/main/scala/algebra/laws/IsSerializable.scala
@@ -6,7 +6,7 @@ import scala.util.DynamicVariable
   * Object with a dynamic variable that allows users to skip the
   * serialization tests for certain instances.
   */
-object IsSerializable {
+private[laws] object IsSerializable {
   val runTests = new DynamicVariable[Boolean](true)
   def apply(): Boolean = runTests.value
 }

--- a/laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -14,6 +14,11 @@ import org.scalatest.FunSuite
 import scala.util.Random
 
 trait LawTestsBase extends FunSuite with Discipline {
+  /**
+    * Runs the supplied thunk without calling the serialization tests.
+    */
+  def withoutSerialization[T](thunk: => T): T =
+    IsSerializable.runTests.withValue(false)(thunk)
 
   implicit val byteLattice: Lattice[Byte] = ByteMinMaxLattice
   implicit val shortLattice: Lattice[Short] = ShortMinMaxLattice
@@ -192,4 +197,3 @@ trait LawTestsBase extends FunSuite with Discipline {
 
   laws[OrderLaws, Int]("fromOrdering").check(_.order(Order.fromOrdering[Int]))
 }
-


### PR DESCRIPTION
Here's a much simpler (in terms of required implementation changes and ease of use) solution to #123. To skip serialization for a block of tests, just pass a thunk to `withoutSerialization`:

```scala
withoutSerialization {
   laws[OrderLaws, Boolean].check(_.order)
}
```

I think this should solve our immediate issue of making the tests reusable for non-serializable instances.