### PR TITLE
Add algebra.std.AllInstances trait

### DIFF
--- a/std/src/main/scala/algebra/std/all.scala
+++ b/std/src/main/scala/algebra/std/all.scala
@@ -1,7 +1,9 @@
 package algebra
 package std
 
-package object all
+package object all extends AllInstances
+
+trait AllInstances
     extends BigIntInstances
     with BooleanInstances
     with ByteInstances


### PR DESCRIPTION
This commit changes the package object `algebra.std.all` to extend a new `AllInstances` trait instead of directly extending a lot of `*Instances` traits. This shouldn't change the behavior of `algebra.std.all`, but makes it possible to extend the new `AllInstances` trait in a package object in client code (e.g., if a user wants to have all instances visible by default in their packages). (This is similar to the `cats.std.AllInstances` trait in [typelevel/cats](https://github.com/typelevel/cats).)