### PR TITLE
Improve the performance of Map's algebras.

### DIFF
--- a/ring/src/main/scala/algebra/ring/Additive.scala
+++ b/ring/src/main/scala/algebra/ring/Additive.scala
@@ -62,6 +62,9 @@ trait AdditiveMonoid[@sp(Int, Long, Float, Double) A] extends Any with AdditiveS
    */
   def sum(as: TraversableOnce[A]): A =
     as.foldLeft(zero)(plus)
+
+  override def trySum(as: TraversableOnce[A]): Option[A] =
+    if (as.isEmpty) None else Some(sum(as))
 }
 
 trait AdditiveCommutativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with AdditiveCommutativeSemigroup[A] {

--- a/ring/src/main/scala/algebra/ring/Multiplicative.scala
+++ b/ring/src/main/scala/algebra/ring/Multiplicative.scala
@@ -63,6 +63,9 @@ trait MultiplicativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with Mul
    */
   def product(as: TraversableOnce[A]): A =
     as.foldLeft(one)(times)
+
+  override def tryProduct(as: TraversableOnce[A]): Option[A] =
+    if (as.isEmpty) None else Some(product(as))
 }
 
 trait MultiplicativeCommutativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] with MultiplicativeCommutativeSemigroup[A] {

--- a/std/src/main/scala/algebra/std/map.scala
+++ b/std/src/main/scala/algebra/std/map.scala
@@ -1,8 +1,10 @@
 package algebra
 package std
 
-import cats.kernel.std.util.StaticMethods.addMap
-import algebra.std.util.StaticMethods.timesMap
+import scala.collection.mutable
+
+import cats.kernel.std.util.StaticMethods
+
 import algebra.ring._
 
 package object map extends MapInstances
@@ -30,23 +32,98 @@ class MapAdditiveMonoid[K, V](implicit V: AdditiveSemigroup[V]) extends Additive
 
   def plus(xs: Map[K, V], ys: Map[K, V]): Map[K, V] =
     if (xs.size <= ys.size) {
-      addMap(xs, ys)((x, y) => V.plus(x, y))
+      xs.foldLeft(ys) { case (my, (k, x)) =>
+        my.updated(k, my.get(k) match {
+          case Some(y) => V.plus(x, y)
+          case None => x
+        })
+      }
     } else {
-      addMap(ys, xs)((y, x) => V.plus(x, y))
+      ys.foldLeft(xs) { case (mx, (k, y)) =>
+        mx.updated(k, mx.get(k) match {
+          case Some(x) => V.plus(x, y)
+          case None => y
+        })
+      }
     }
+
+  override def sumN(a: Map[K, V], n: Int): Map[K, V] =
+    if (n > 0) a.map { case (k, v) => (k, V.sumN(v, n)) }
+    else if (n == 0) zero
+    else throw new IllegalArgumentException("Illegal negative exponent to sumN: %s" format n)
+
+  override def sum(as: TraversableOnce[Map[K, V]]): Map[K, V] = {
+    val acc = mutable.Map.empty[K, V]
+    as.foreach { m =>
+      val it = m.iterator
+      while (it.hasNext) {
+        val (k, y) = it.next
+        acc.get(k) match {
+          case None => acc(k) = y
+          case Some(x) => acc(k) = V.plus(x, y)
+        }
+      }
+    }
+    StaticMethods.wrapMutableMap(acc)
+  }
 }
 
 class MapSemiring[K, V](implicit V: Semiring[V]) extends MapAdditiveMonoid[K, V] with Semiring[Map[K, V]] {
 
   def times(xs: Map[K, V], ys: Map[K, V]): Map[K, V] =
+    // we figure out which of our maps is smaller, iterate over its
+    // keys, see which of those are in the larger map, and add the
+    // resulting product to our result map.
     if (xs.size <= ys.size) {
-      timesMap(xs, ys)((x, y) => V.times(x, y))
+      xs.foldLeft(Map.empty[K, V]) { case (m, (k, x)) =>
+        ys.get(k) match {
+          case Some(y) => m.updated(k, V.times(x, y))
+          case None => m
+        }
+      }
     } else {
-      timesMap(ys, xs)((y, x) => V.times(x, y))
+      ys.foldLeft(Map.empty[K, V]) { case (m, (k, y)) =>
+        xs.get(k) match {
+          case Some(x) => m.updated(k, V.times(x, y))
+          case None => m
+        }
+      }
     }
 
   override def pow(x: Map[K, V], n: Int): Map[K, V] =
     if (n < 1) throw new IllegalArgumentException(s"non-positive exponent: $n")
     else if (n == 1) x
     else x.map { case (k, v) => (k, V.pow(v, n)) }
+
+  override def tryProduct(as: TraversableOnce[Map[K, V]]): Option[Map[K, V]] =
+    if (as.isEmpty) {
+      None
+    } else {
+      val acc = mutable.Map.empty[K, V]
+      var ready: Boolean = false
+      as.foreach { m =>
+        if (ready) {
+          // at this point all we can do is modify or remove
+          // keys. since any "missing" key is effectively zero, and
+          // since 0 * x = 0, we ignore any keys not already in our
+          // accumulator.
+          val it = acc.iterator
+          while (it.hasNext) {
+            val (k, x) = it.next
+            m.get(k) match {
+              case None => acc -= k
+              case Some(y) => acc(k) = V.times(x, y)
+            }
+          }
+        } else {
+          // we have to initialize our accumulator (`acc`) with the
+          // very first element of `as`. if there is only one map in
+          // our collection we want to return exactly those values.
+          val it = m.iterator
+          while (it.hasNext) acc += it.next
+          ready = true
+        }
+      }
+      Some(StaticMethods.wrapMutableMap(acc))
+    }
 }


### PR DESCRIPTION
We noticed an issue in cats-kernel where operations over Maps were
incredibly slow. This commit ports those fixes over here, where our
additive/multiplicative monoids experienced the same issues.

Review by @johnynek 