### PR TITLE
Work-around for SI-8431.

### DIFF
--- a/core/src/main/scala/algebra/lattice/Bool.scala
+++ b/core/src/main/scala/algebra/lattice/Bool.scala
@@ -29,7 +29,8 @@ trait Bool[@sp(Int, Long) A] extends Any with Heyting[A] with GenBool[A] { self 
 
   // xor is already defined in both Heyting and GenBool.
   // In Bool, the definitions coincide, so we just use one of them.
-  override def xor(a: A, b: A): A = super.xor(a, b)
+  override def xor(a: A, b: A): A =
+    or(without(a, b), without(b, a))
 
   override def dual: Bool[A] = new DualBool(this)
 


### PR DESCRIPTION
If we use `super` in the implementation of a specialized trait it can
cause problems for implementing classes downstream. I hit this bug [1]
when trying to get Spire using Algebra.

[1] https://issues.scala-lang.org/browse/SI-8431